### PR TITLE
Add sports config and dynamic scoreboard/teams panels

### DIFF
--- a/wwwroot/js/components/scoreboardPanel.js
+++ b/wwwroot/js/components/scoreboardPanel.js
@@ -1,7 +1,87 @@
-export function renderScoreboardPanel(container, sport='Football') {
-    container.innerHTML = `<div class='text-gray-500'>Scoreboard controls for <span class="font-semibold">${sport}</span> coming soon.</div>`;
-    if (!container.dataset.heartbeat) {
-        setInterval(() => localStorage.setItem('sportsHeartbeat', Date.now().toString()), 5000);
-        container.dataset.heartbeat = 'true';
+import { ref, set, onValue } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js";
+import { getDatabaseInstance } from "../firebaseApp.js";
+import { sportsData } from "../sportsConfig.js";
+
+const db = getDatabaseInstance();
+
+function getScoreboardRef(eventId) {
+    return ref(db, `scoreboard/${eventId}`);
+}
+
+export function renderScoreboardPanel(container, sport = 'Football', eventId = 'demo') {
+    const cfg = sportsData[sport] || sportsData['Football'];
+
+    onValue(getScoreboardRef(eventId), snap => {
+        const data = snap.val() || defaultData();
+        render(data);
+    });
+
+    function defaultData() {
+        const teams = Array.from({ length: cfg.teamCount }).map((_, i) => ({ name: `Team ${i + 1}`, score: 0 }));
+        const base = { teams };
+        if (cfg.scoreboard.periods) base.period = 1;
+        if (cfg.scoreboard.time) base.time = '00:00';
+        if (cfg.scoreboard.round) base.round = 1;
+        if (cfg.scoreboard.sets) base.sets = teams.map(() => 0);
+        if (cfg.scoreboard.games) base.games = teams.map(() => 0);
+        if (cfg.scoreboard.frames) base.frames = teams.map(() => 0);
+        if (cfg.scoreboard.legs) base.legs = teams.map(() => 0);
+        if (cfg.scoreboard.points) base.points = teams.map(() => 0);
+        return base;
+    }
+
+    function render(data) {
+        container.innerHTML = `
+            <div class='scoreboard-panel'>
+                <h2 class="font-bold text-lg mb-2">${sport} Scoreboard</h2>
+                <div id="sb-fields" class="space-y-2"></div>
+                <button id="sb-save" class="control-button btn-sm mt-2">Save</button>
+            </div>`;
+        const fieldsDiv = container.querySelector('#sb-fields');
+        const htmlParts = [];
+        data.teams.forEach((t, i) => {
+            htmlParts.push(`<div><input class="border p-1 w-24 mr-2" id="team-name-${i}" value="${t.name}"><input type="number" class="border p-1 w-16" id="team-score-${i}" value="${t.score}"></div>`);
+        });
+        if (cfg.scoreboard.periods) {
+            htmlParts.push(`<div><label class="mr-2">${cfg.scoreboard.periodLabel || 'Period'}:</label><input type="number" class="border p-1 w-16" id="sb-period" value="${data.period || 1}"></div>`);
+        }
+        if (cfg.scoreboard.time) {
+            htmlParts.push(`<div><label class="mr-2">Time:</label><input type="text" class="border p-1 w-24" id="sb-time" value="${data.time || ''}" placeholder="mm:ss"></div>`);
+        }
+        if (cfg.scoreboard.round) {
+            htmlParts.push(`<div><label class="mr-2">Round:</label><input type="number" class="border p-1 w-16" id="sb-round" value="${data.round || 1}"></div>`);
+        }
+        if (cfg.scoreboard.sets) {
+            htmlParts.push(`<div><label>Sets:</label>${data.teams.map((_,i)=>`<input type="number" class="border p-1 w-12 mx-1" id="sb-set-${i}" value="${(data.sets && data.sets[i]) || 0}">`).join('')}</div>`);
+        }
+        if (cfg.scoreboard.games) {
+            htmlParts.push(`<div><label>Games:</label>${data.teams.map((_,i)=>`<input type="number" class="border p-1 w-12 mx-1" id="sb-game-${i}" value="${(data.games && data.games[i]) || 0}">`).join('')}</div>`);
+        }
+        if (cfg.scoreboard.frames) {
+            htmlParts.push(`<div><label>Frames:</label>${data.teams.map((_,i)=>`<input type="number" class="border p-1 w-12 mx-1" id="sb-frame-${i}" value="${(data.frames && data.frames[i]) || 0}">`).join('')}</div>`);
+        }
+        if (cfg.scoreboard.legs) {
+            htmlParts.push(`<div><label>Legs:</label>${data.teams.map((_,i)=>`<input type="number" class="border p-1 w-12 mx-1" id="sb-leg-${i}" value="${(data.legs && data.legs[i]) || 0}">`).join('')}</div>`);
+        }
+        if (cfg.scoreboard.points) {
+            htmlParts.push(`<div><label>Points:</label>${data.teams.map((_,i)=>`<input type="number" class="border p-1 w-12 mx-1" id="sb-point-${i}" value="${(data.points && data.points[i]) || 0}">`).join('')}</div>`);
+        }
+        fieldsDiv.innerHTML = htmlParts.join('');
+        container.querySelector('#sb-save').onclick = async () => {
+            const newData = { teams: data.teams.map((_,i)=>({ name: container.querySelector(`#team-name-${i}`).value, score: parseInt(container.querySelector(`#team-score-${i}`).value) || 0 })) };
+            if (cfg.scoreboard.periods) newData.period = parseInt(container.querySelector('#sb-period').value) || 1;
+            if (cfg.scoreboard.time) newData.time = container.querySelector('#sb-time').value;
+            if (cfg.scoreboard.round) newData.round = parseInt(container.querySelector('#sb-round').value) || 1;
+            if (cfg.scoreboard.sets) newData.sets = data.teams.map((_,i)=>parseInt(container.querySelector(`#sb-set-${i}`).value) || 0);
+            if (cfg.scoreboard.games) newData.games = data.teams.map((_,i)=>parseInt(container.querySelector(`#sb-game-${i}`).value) || 0);
+            if (cfg.scoreboard.frames) newData.frames = data.teams.map((_,i)=>parseInt(container.querySelector(`#sb-frame-${i}`).value) || 0);
+            if (cfg.scoreboard.legs) newData.legs = data.teams.map((_,i)=>parseInt(container.querySelector(`#sb-leg-${i}`).value) || 0);
+            if (cfg.scoreboard.points) newData.points = data.teams.map((_,i)=>parseInt(container.querySelector(`#sb-point-${i}`).value) || 0);
+            await set(getScoreboardRef(eventId), newData);
+        };
+        if (!container.dataset.heartbeat) {
+            setInterval(() => localStorage.setItem('sportsHeartbeat', Date.now().toString()), 5000);
+            container.dataset.heartbeat = 'true';
+        }
     }
 }

--- a/wwwroot/js/components/teamsPanel.js
+++ b/wwwroot/js/components/teamsPanel.js
@@ -1,5 +1,6 @@
 import { ref, set, onValue } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js";
 import { getDatabaseInstance } from "../firebaseApp.js";
+import { sportsData } from "../sportsConfig.js";
 
 const db = getDatabaseInstance();
 
@@ -7,41 +8,94 @@ function getTeamsRef(eventId) {
     return ref(db, `teams/${eventId}`);
 }
 
-export function renderTeamsPanel(container, eventId) {
+async function uploadToServer(file, path) {
+    try {
+        const fd = new FormData();
+        fd.append('file', file);
+        fd.append('path', path.replace(/^\/+/, ''));
+        const resp = await fetch('upload.php', { method: 'POST', body: fd });
+        if (!resp.ok) throw new Error('upload failed');
+        const data = await resp.json();
+        return data.url;
+    } catch (err) {
+        console.error('Upload failed', err);
+        return null;
+    }
+}
+
+export function renderTeamsPanel(container, eventId, sport = 'Football') {
+    const cfg = sportsData[sport] || sportsData['Football'];
+
     onValue(getTeamsRef(eventId), (snap) => {
-        const data = snap.val() || { teamA: { name: 'Team A', players: [] }, teamB: { name: 'Team B', players: [] } };
+        const data = snap.val() || defaultData();
         render(data);
     });
 
+    function defaultData() {
+        const playerSlots = cfg.playersPerTeam + (cfg.subs || 0);
+        const players = Array.from({ length: playerSlots }).map(() => ({ name: '', pos: '' }));
+        return { teamA: { name: 'Team A', logo: '', players: players.slice() }, teamB: { name: 'Team B', logo: '', players: players.slice() } };
+    }
+
     function render(data) {
+        const posOpts = cfg.positions.map(p=>`<option value="${p}">${p}</option>`).join('');
+        const playerRows = (teamKey, team) => team.players.map((pl,idx)=>`<tr><td><input class="border p-1 w-full" id="${teamKey}-name-${idx}" value="${pl.name}"></td><td><select class="border p-1 w-full" id="${teamKey}-pos-${idx}"><option value=""></option>${posOpts}</select></td></tr>`).join('');
         container.innerHTML = `
             <div class='teams-panel'>
                 <h2 class="font-bold text-lg mb-2">Teams</h2>
-                <div class="flex gap-4 mb-4">
+                <div class="flex gap-4 mb-4 text-sm">
                     <div class="flex-1">
                         <input class="border p-1 w-full mb-2" id="team-a-name" value="${data.teamA.name}" />
-                        <textarea id="team-a-list" class="border p-1 w-full" rows="6" placeholder="Name - Position">${data.teamA.players.map(p=>`${p.name} - ${p.pos}`).join('\n')}</textarea>
+                        <div class="flex items-center gap-2 mb-1"><input type="file" id="team-a-logo-file" accept="image/*" /><button type="button" id="team-a-upload" class="control-button btn-xs">Upload</button></div>
+                        <input class="border p-1 w-full mb-2" id="team-a-logo" placeholder="Logo URL" value="${data.teamA.logo || ''}" />
+                        <table class="w-full"><tbody>${playerRows('a', data.teamA)}</tbody></table>
                     </div>
                     <div class="flex-1">
                         <input class="border p-1 w-full mb-2" id="team-b-name" value="${data.teamB.name}" />
-                        <textarea id="team-b-list" class="border p-1 w-full" rows="6" placeholder="Name - Position">${data.teamB.players.map(p=>`${p.name} - ${p.pos}`).join('\n')}</textarea>
+                        <div class="flex items-center gap-2 mb-1"><input type="file" id="team-b-logo-file" accept="image/*" /><button type="button" id="team-b-upload" class="control-button btn-xs">Upload</button></div>
+                        <input class="border p-1 w-full mb-2" id="team-b-logo" placeholder="Logo URL" value="${data.teamB.logo || ''}" />
+                        <table class="w-full"><tbody>${playerRows('b', data.teamB)}</tbody></table>
                     </div>
                 </div>
                 <button id="teams-save" class="control-button btn-sm">Save</button>
-            </div>
-        `;
+            </div>`;
+        data.teamA.players.forEach((pl,idx)=>{ const sel=container.querySelector(`#a-pos-${idx}`); if(sel) sel.value=pl.pos; });
+        data.teamB.players.forEach((pl,idx)=>{ const sel=container.querySelector(`#b-pos-${idx}`); if(sel) sel.value=pl.pos; });
+        container.querySelector('#team-a-upload').onclick = async () => {
+            const file = container.querySelector('#team-a-logo-file').files[0];
+            if (file) {
+                const path = `uploads/${eventId}/teams/teamA_${file.name}`;
+                const url = await uploadToServer(file, path);
+                if (url) container.querySelector('#team-a-logo').value = url;
+            }
+        };
+        container.querySelector('#team-b-upload').onclick = async () => {
+            const file = container.querySelector('#team-b-logo-file').files[0];
+            if (file) {
+                const path = `uploads/${eventId}/teams/teamB_${file.name}`;
+                const url = await uploadToServer(file, path);
+                if (url) container.querySelector('#team-b-logo').value = url;
+            }
+        };
         container.querySelector('#teams-save').onclick = async () => {
-            const teamAPlayers = container.querySelector('#team-a-list').value.split('\n').filter(Boolean).map(l=>{
-                const [n,p=''] = l.split('-').map(s=>s.trim());
-                return { name:n, pos:p };
-            });
-            const teamBPlayers = container.querySelector('#team-b-list').value.split('\n').filter(Boolean).map(l=>{
-                const [n,p=''] = l.split('-').map(s=>s.trim());
-                return { name:n, pos:p };
-            });
+            const playerSlots = cfg.playersPerTeam + (cfg.subs || 0);
+            const getPlayers = (teamKey) => {
+                return Array.from({length: playerSlots}).map((_,i)=>({
+                    name: container.querySelector(`#${teamKey}-name-${i}`).value,
+                    pos: container.querySelector(`#${teamKey}-pos-${i}`).value
+                }));
+            };
             const newData = {
-                teamA: { name: container.querySelector('#team-a-name').value, players: teamAPlayers },
-                teamB: { name: container.querySelector('#team-b-name').value, players: teamBPlayers }
+                teamA: {
+                    name: container.querySelector('#team-a-name').value,
+                    logo: container.querySelector('#team-a-logo').value,
+                    players: getPlayers('a')
+                },
+                teamB: {
+                    name: container.querySelector('#team-b-name').value,
+                    logo: container.querySelector('#team-b-logo').value,
+                    players: getPlayers('b')
+                }
             };
             await set(getTeamsRef(eventId), newData);
         };

--- a/wwwroot/js/main-control.js
+++ b/wwwroot/js/main-control.js
@@ -168,12 +168,12 @@ async function initializeComponents(eventData) {
             renderSportPanel(document.getElementById('sport-panel'), eventData, async (id, sport) => {
                 await updateEventMetadata(eventId, { ...eventData, sport });
                 eventData.sport = sport;
-                renderScoreboardPanel(document.getElementById('scoreboard-panel'), sport);
+                renderScoreboardPanel(document.getElementById('scoreboard-panel'), sport, eventId);
             });
-            renderScoreboardPanel(document.getElementById('scoreboard-panel'), eventData.sport);
+            renderScoreboardPanel(document.getElementById('scoreboard-panel'), eventData.sport, eventId);
             renderLineupPanel(document.getElementById('lineups-panel'));
             renderStatsPanel(document.getElementById('stats-panel'));
-            renderTeamsPanel(document.getElementById('teams-panel'), eventId);
+            renderTeamsPanel(document.getElementById('teams-panel'), eventId, sport);
         } else {
             renderProgramPreview(document.getElementById('schedule-panel'), eventData, onOverlayStateChange);
         }
@@ -188,12 +188,12 @@ async function initializeComponents(eventData) {
         renderSportPanel(document.getElementById('sport-panel'), eventData, async (id, sport) => {
             await updateEventMetadata(eventId, { ...eventData, sport });
             eventData.sport = sport;
-            renderScoreboardPanel(document.getElementById('scoreboard-panel'), sport);
+            renderScoreboardPanel(document.getElementById('scoreboard-panel'), sport, eventId);
         });
-        renderScoreboardPanel(document.getElementById('scoreboard-panel'), eventData.sport);
+        renderScoreboardPanel(document.getElementById('scoreboard-panel'), eventData.sport, eventId);
         renderLineupPanel(document.getElementById('lineups-panel'));
         renderStatsPanel(document.getElementById('stats-panel'));
-        renderTeamsPanel(document.getElementById('teams-panel'), eventId);
+        renderTeamsPanel(document.getElementById('teams-panel'), eventId, eventData.sport);
     } else {
         renderProgramPreview(document.getElementById('schedule-panel'), eventData, onOverlayStateChange);
     }

--- a/wwwroot/js/main-graphics.js
+++ b/wwwroot/js/main-graphics.js
@@ -156,12 +156,12 @@ async function initializeComponents(eventData) {
             renderSportPanel(document.getElementById('sport-panel'), eventData, async (id,sport)=>{
                 await updateEventMetadata(eventId,{...eventData,sport});
                 eventData.sport = sport;
-                renderScoreboardPanel(document.getElementById('scoreboard-panel'), sport);
+                renderScoreboardPanel(document.getElementById('scoreboard-panel'), sport, eventId);
             });
-            renderScoreboardPanel(document.getElementById('scoreboard-panel'), eventData.sport);
+            renderScoreboardPanel(document.getElementById('scoreboard-panel'), eventData.sport, eventId);
             renderLineupPanel(document.getElementById('lineups-panel'));
             renderStatsPanel(document.getElementById('stats-panel'));
-            renderTeamsPanel(document.getElementById('teams-panel'), eventId);
+        renderTeamsPanel(document.getElementById('teams-panel'), eventId, sport);
         } else {
             renderProgramPreview(document.getElementById('schedule-panel'), eventData, onOverlayStateChange);
         }
@@ -173,12 +173,12 @@ async function initializeComponents(eventData) {
         renderSportPanel(document.getElementById('sport-panel'), eventData, async (id,sport)=>{
             await updateEventMetadata(eventId,{...eventData,sport});
             eventData.sport = sport;
-            renderScoreboardPanel(document.getElementById('scoreboard-panel'), sport);
+            renderScoreboardPanel(document.getElementById('scoreboard-panel'), sport, eventId);
         });
-        renderScoreboardPanel(document.getElementById('scoreboard-panel'), eventData.sport);
+        renderScoreboardPanel(document.getElementById('scoreboard-panel'), eventData.sport, eventId);
         renderLineupPanel(document.getElementById('lineups-panel'));
         renderStatsPanel(document.getElementById('stats-panel'));
-        renderTeamsPanel(document.getElementById('teams-panel'), eventId);
+        renderTeamsPanel(document.getElementById('teams-panel'), eventId, eventData.sport);
     } else {
         renderProgramPreview(document.getElementById('schedule-panel'), eventData, onOverlayStateChange);
     }

--- a/wwwroot/js/sportsConfig.js
+++ b/wwwroot/js/sportsConfig.js
@@ -1,0 +1,90 @@
+export const sportsData = {
+  "Football": {
+    teamCount: 2,
+    playersPerTeam: 11,
+    subs: 5,
+    positions: ["GK","LB","CB","RB","LWB","RWB","DM","CM","AM","LW","RW","ST"],
+    scoreboard: { periods: 2, periodLabel: "Half", time: true }
+  },
+  "Rugby": {
+    teamCount: 2,
+    playersPerTeam: 15,
+    subs: 8,
+    positions: [
+      "Loosehead Prop","Hooker","Tighthead Prop","Lock","Lock",
+      "Flanker","Flanker","Number 8","Scrum-half","Fly-half",
+      "Wing","Inside Centre","Outside Centre","Wing","Full-back"
+    ],
+    scoreboard: { periods: 2, periodLabel: "Half", time: true }
+  },
+  "Hockey": {
+    teamCount: 2,
+    playersPerTeam: 11,
+    subs: 5,
+    positions: ["Goalkeeper","Defender","Midfielder","Forward"],
+    scoreboard: { periods: 4, periodLabel: "Quarter", time: true }
+  },
+  "Ice Hockey": {
+    teamCount: 2,
+    playersPerTeam: 6,
+    subs: 6,
+    positions: ["Goalie","Defense","Center","Winger"],
+    scoreboard: { periods: 3, periodLabel: "Period", time: true }
+  },
+  "Boxing": {
+    teamCount: 2,
+    playersPerTeam: 1,
+    subs: 0,
+    positions: ["Fighter"],
+    scoreboard: { round: true, timer: true }
+  },
+  "Darts": {
+    teamCount: 2,
+    playersPerTeam: 1,
+    subs: 0,
+    positions: ["Player"],
+    scoreboard: { sets: true, legs: true }
+  },
+  "Snooker": {
+    teamCount: 2,
+    playersPerTeam: 1,
+    subs: 0,
+    positions: ["Player"],
+    scoreboard: { frames: true }
+  },
+  "Tennis": {
+    teamCount: 2,
+    playersPerTeam: 1,
+    subs: 0,
+    positions: ["Player"],
+    scoreboard: { sets: true, games: true }
+  },
+  "Table Tennis": {
+    teamCount: 2,
+    playersPerTeam: 1,
+    subs: 0,
+    positions: ["Player"],
+    scoreboard: { games: true, points: true }
+  },
+  "Pool": {
+    teamCount: 2,
+    playersPerTeam: 1,
+    subs: 0,
+    positions: ["Player"],
+    scoreboard: { frames: true }
+  },
+  "Basketball": {
+    teamCount: 2,
+    playersPerTeam: 5,
+    subs: 7,
+    positions: ["PG","SG","SF","PF","C"],
+    scoreboard: { periods: 4, periodLabel: "Quarter", time: true }
+  },
+  "Netball": {
+    teamCount: 2,
+    playersPerTeam: 7,
+    subs: 5,
+    positions: ["GS","GA","WA","C","WD","GD","GK"],
+    scoreboard: { periods: 4, periodLabel: "Quarter", time: true }
+  }
+};


### PR DESCRIPTION
## Summary
- implement sport-specific configuration in `sportsConfig.js`
- update scoreboard panel with fields based on selected sport and store values in Firebase
- update teams panel to generate player/position inputs using sport config
- pass event id when rendering scoreboard and teams panels
- allow uploading team logos with PHP backend

## Testing
- `node -c wwwroot/js/components/scoreboardPanel.js`
- `node -c wwwroot/js/components/teamsPanel.js`
- `node -c wwwroot/js/main-graphics.js`
- `node -c wwwroot/js/main-control.js`


------
https://chatgpt.com/codex/tasks/task_e_686063cd562c8323b17bdfcc79be826b