### PR TITLE
Enhance intro graphics controls

### DIFF
--- a/wwwroot/app/css/custom.css
+++ b/wwwroot/app/css/custom.css
@@ -517,6 +517,22 @@ html,body { margin: 0; width:100%; height:100%; overflow:hidden; }
 .stats-box th, .stats-box td { padding:0.25rem 0.5rem; text-align:center; }
 .stats-box th { background:var(--brand-color); }
 .stats-box tbody tr:nth-child(odd) { background:rgba(255,255,255,0.1); }
+.stats-box.minimal { background:transparent; padding:0.5rem 1rem; }
+.stats-box.minimal th { background:transparent; }
+.stats-box.minimal tbody tr:nth-child(odd) { background:transparent; }
+
+.stat-head.fade-in { animation: statFadeIn 0.5s ease forwards; }
+.stat-body.slide-down { animation: statSlideDown 0.5s ease forwards; }
+
+@keyframes statFadeIn {
+  from { opacity:0; }
+  to { opacity:1; }
+}
+
+@keyframes statSlideDown {
+  from { opacity:0; transform:translateY(-10px); }
+  to { opacity:1; transform:translateY(0); }
+}
 
 #stoppage-overlay {
   position:absolute;

--- a/wwwroot/app/css/custom.css
+++ b/wwwroot/app/css/custom.css
@@ -420,13 +420,14 @@ html,body { margin: 0; width:100%; height:100%; overflow:hidden; }
 .teams-panel select,
 .teams-panel textarea,
 .lineup-panel input,
-.lineup-panel select {
+.lineup-panel select,
+#active-graphics select {
   color: #000;
 }
 
 /* Ensure text is readable in stats panel */
 .stats-panel {
-  color: #000;
+  color: #f3f4f6;
 }
 .stats-panel input,
 .stats-panel select,

--- a/wwwroot/app/js/components/activeGraphicsPanel.js
+++ b/wwwroot/app/js/components/activeGraphicsPanel.js
@@ -152,9 +152,9 @@ export function renderActiveGraphicsPanel(container, eventId, mode = 'live') {
         else if(type==='stat') updateOverlayState(eventId,{statVisible:false,statPreviewVisible:false});
         else if(type==='stinger') updateOverlayState(eventId,{stingerVisible:false,stingerPreviewVisible:false});
         else if(type==='scoreboard') updateOverlayState(eventId,{scoreboardVisible:false,scoreboardPreviewVisible:false});
-        else if(type==='fixtures') updateOverlayState(eventId,{fixturesVisible:false});
-        else if(type==='formation') updateOverlayState(eventId,{formationVisible:false});
-        else if(type==='course') updateOverlayState(eventId,{courseVisible:false});
+        else if(type==='fixtures') updateOverlayState(eventId,{fixturesVisible:false,fixturesPreviewVisible:false});
+        else if(type==='formation') updateOverlayState(eventId,{formationVisible:false,formationPreviewVisible:false});
+        else if(type==='course') updateOverlayState(eventId,{courseVisible:false,coursePreviewVisible:false});
     }
 
     function renderFav() {

--- a/wwwroot/app/js/components/activeGraphicsPanel.js
+++ b/wwwroot/app/js/components/activeGraphicsPanel.js
@@ -103,7 +103,14 @@ export function renderActiveGraphicsPanel(container, eventId, mode = 'live') {
         const pid = e.target.getAttribute('data-player');
         if(pid){
             const entry = matchLogs.find(l=>l.id===pid);
-            if(entry){ entry.player = e.target.value; updateMatchLogEntry(eventId,pid,entry); }
+            if(entry){
+                entry.player = e.target.value;
+                entry.playerName = e.target.value;
+                const teamPlayers = entry.team==='a'?teamsData?.teamA?.players||[]:teamsData?.teamB?.players||[];
+                const pl = teamPlayers.find(p=>p.name===e.target.value);
+                entry.playerNumber = pl?.number || '';
+                updateMatchLogEntry(eventId,pid,entry);
+            }
         }
     });
 
@@ -175,7 +182,8 @@ export function renderActiveGraphicsPanel(container, eventId, mode = 'live') {
         const rows = (matchLogs||[]).map(e=>{
             const team = e.team==='a'?teamsData?.teamA?.name||'Team A':teamsData?.teamB?.name||'Team B';
             const players = e.team==='a'?teamsData?.teamA?.players||[]:teamsData?.teamB?.players||[];
-            const opts = ['<option value="">-</option>', ...players.map(p=>`<option ${e.player===p.name?'selected':''} value="${p.name}">${p.name}</option>`)].join('');
+            const selectedName = e.playerName || e.player || '';
+            const opts = ['<option value="">-</option>', ...players.map(p=>`<option ${selectedName===p.name?'selected':''} value="${p.name}">${p.number?`#${p.number} `:''}${p.name}</option>`)].join('');
             return `<tr data-id="${e.id}"><td class='pr-2'>${e.time}</td><td>${team}</td><td>${e.type}</td><td><select data-player="${e.id}" class='border p-1'>${opts}</select></td></tr>`;
         }).join('');
         logsTable.innerHTML = `<thead><tr><th class='pr-2'>Time</th><th>Team</th><th>Type</th><th>Player</th></tr></thead><tbody>${rows}</tbody>`;

--- a/wwwroot/app/js/components/brandingModal.js
+++ b/wwwroot/app/js/components/brandingModal.js
@@ -43,7 +43,7 @@ export function renderBrandingModal(container, opts) {
             <div class="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
                 <div class="bg-white text-black p-6 rounded shadow-lg min-w-[340px] max-w-[95vw] max-h-[90vh] overflow-y-auto">
                     <h2 class="font-bold text-xl mb-4">${isUser ? 'Account Branding' : 'Event Branding'}</h2>
-                    <form id="branding-form" class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <form id="branding-form" class="grid grid-cols-2 gap-4">
                         <div>
                             <label class="block text-sm font-semibold mb-1">Primary Color</label>
                             <input type="color" name="primaryColor" value="${branding.primaryColor}" />
@@ -62,12 +62,12 @@ export function renderBrandingModal(container, opts) {
                                 ${FONT_OPTIONS.map(f => `<option value="${f}"${branding.font === f ? ' selected' : ''}>${f}</option>`).join('')}
                             </select>
                         </div>
-                        <div class="sm:col-span-2">
+                        <div class="col-span-2">
                             <label class="block text-sm font-semibold mb-1">Primary Logo</label>
                             <input type="file" name="logoPrimary" accept="image/*" class="mb-1" />
                             ${branding.logoPrimary ? `<img src="${resolveAssetPath(branding.logoPrimary)}" alt="Primary Logo" class="h-10 mt-1" />` : ''}
                         </div>
-                        <div class="sm:col-span-2">
+                        <div class="col-span-2">
                             <label class="block text-sm font-semibold mb-1">Secondary Logo</label>
                             <input type="file" name="logoSecondary" accept="image/*" class="mb-1" />
                             ${branding.logoSecondary ? `<img src="${resolveAssetPath(branding.logoSecondary)}" alt="Secondary Logo" class="h-10 mt-1" />` : ''}
@@ -88,7 +88,7 @@ export function renderBrandingModal(container, opts) {
                                 <option value="center"${branding.scheduleLayout==='center'?' selected':''}>Center Box</option>
                             </select>
                         </div>
-                        <div class="sm:col-span-2">
+                        <div class="col-span-2">
                             <label class="block text-sm font-semibold mb-1">Social Template Style</label>
                             <select name="socialTemplateStyle" class="border p-1 w-full">
                                 <option value="style1"${!branding.socialTemplateStyle || branding.socialTemplateStyle==='style1'?' selected':''}>Style 1</option>
@@ -96,7 +96,15 @@ export function renderBrandingModal(container, opts) {
                                 <option value="style3"${branding.socialTemplateStyle==='style3'?' selected':''}>Style 3</option>
                             </select>
                         </div>
-                        <div class="col-span-1 sm:col-span-2 flex gap-2 mt-4">
+                        <div class="col-span-2">
+                            <label class="block text-sm font-semibold mb-1">Preview</label>
+                            <div id="branding-preview" class="p-4 rounded border" style="background:${branding.primaryColor}; color:${branding.secondaryColor2}; font-family:${branding.font};">Sample Text</div>
+                        </div>
+                        <label class="col-span-2 flex items-center gap-2 mt-2">
+                            <input type="checkbox" name="applyAll" />
+                            <span class="text-sm">Override existing graphics</span>
+                        </label>
+                        <div class="col-span-2 flex gap-2 mt-4">
                             <button type="submit" class="control-button btn-sm">Save</button>
                             <button type="button" id="branding-cancel" class="control-button btn-sm bg-gray-400 hover:bg-gray-600">Cancel</button>
                         </div>
@@ -134,12 +142,25 @@ export function renderBrandingModal(container, opts) {
                 sponsors: branding.sponsors || [],
                 scheduleSponsorPlacement: data.scheduleSponsorPlacement || branding.scheduleSponsorPlacement || 'bottom-spaced',
                 scheduleLayout: data.scheduleLayout || branding.scheduleLayout || 'corner',
-                socialTemplateStyle: data.socialTemplateStyle || branding.socialTemplateStyle || 'style1'
+                socialTemplateStyle: data.socialTemplateStyle || branding.socialTemplateStyle || 'style1',
+                overrideAll: form.applyAll.checked
             };
             saveBranding(targetId, newBranding, isUser);
             container.classList.add('hidden');
         };
         container.querySelector('#branding-cancel').onclick = () => container.classList.add('hidden');
+
+        const preview = form.querySelector('#branding-preview');
+        const updatePreview = () => {
+            preview.style.background = form.primaryColor.value;
+            preview.style.color = form.secondaryColor2.value;
+            preview.style.fontFamily = form.font.value;
+        };
+        ['primaryColor','secondaryColor2','font'].forEach(name => {
+            form[name].addEventListener('input', updatePreview);
+            form[name].addEventListener('change', updatePreview);
+        });
+        updatePreview();
     });
 }
 

--- a/wwwroot/app/js/components/graphicsPanel.js
+++ b/wwwroot/app/js/components/graphicsPanel.js
@@ -303,12 +303,20 @@ export function renderGraphicsPanel(container, eventData, mode = 'live') {
                 const on = playerOnSel.value;
                 let subtitle = '';
                 let playerField = '';
+                let playerName = '';
+                let playerNumber = '';
                 if (type === 'substitution') {
                     subtitle = `${off} → ${on}`;
                     playerField = subtitle;
+                    playerName = off;
+                    const offObj = teamsData[teamKey]?.players.find(p=>p.name===off);
+                    playerNumber = offObj?.number || '';
                 } else {
                     subtitle = off;
                     playerField = off;
+                    const plObj = teamsData[teamKey]?.players.find(p=>p.name===off);
+                    playerName = plObj?.name || off;
+                    playerNumber = plObj?.number || '';
                 }
                 const sb = overlayState.scoreboard || {};
                 const parseTime = str => { const [m = '0', s = '0'] = str.split(':'); return parseInt(m) * 60 + parseInt(s); };
@@ -319,7 +327,8 @@ export function renderGraphicsPanel(container, eventData, mode = 'live') {
                     secs = sb.timeDirection === 'down' ? Math.max(0,(sb.timerBase||0) - elapsed) : (sb.timerBase||0) + elapsed;
                 }
                 const timeStr = formatTime(secs);
-                await addMatchLog(eventId,{ ts: Date.now(), type, team: teamKey==='teamA'?'a':'b', player: playerField, time: timeStr });
+                const logEntry = { ts: Date.now(), type, team: teamKey==='teamA'?'a':'b', player: playerField, playerName, playerNumber, time: timeStr };
+                await addMatchLog(eventId, logEntry);
                 const obj = {
                     id: (Date.now()+Math.random()).toString(36),
                     title: `${teamName} ${type.charAt(0).toUpperCase()+type.slice(1)}`,

--- a/wwwroot/app/js/components/graphicsPanel.js
+++ b/wwwroot/app/js/components/graphicsPanel.js
@@ -1,5 +1,5 @@
 import { setGraphicsData, updateGraphicsData, getGraphicsData, listenGraphicsData, listenFavorites, updateFavorites, addMatchLog, listenOverlayState } from '../firebase.js';
-import { ref, onValue } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js';
+import { ref, onValue, set } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js';
 import { getDatabaseInstance } from '../firebaseApp.js';
 import { sportsData } from '../sportsConfig.js';
 
@@ -52,10 +52,12 @@ export function renderGraphicsPanel(container, eventData, mode = 'live') {
     const sportsMode = eventType === 'sports';
     let teamsData = null;
     let logEvents = [];
+    let db;
+    let teamsRef;
 
     if (sportsMode) {
-        const db = getDatabaseInstance();
-        const teamsRef = ref(db, `teams/${eventId}`);
+        db = getDatabaseInstance();
+        teamsRef = ref(db, `teams/${eventId}`);
         onValue(teamsRef, snap => { teamsData = snap.val(); renderPanel(); });
         logEvents = getLogEventsForSport(eventData.sport);
     }
@@ -282,10 +284,13 @@ export function renderGraphicsPanel(container, eventData, mode = 'live') {
 
             const fillPlayers = () => {
                 const teamKey = teamSel.value;
-                const players = (teamsData[teamKey]?.players || []).map(p => p.name);
-                const opts = ['<option value=""></option>', ...players.map(p=>`<option value="${p}">${p}</option>`)];
-                playerSel.innerHTML = opts.join('');
-                playerOnSel.innerHTML = opts.join('');
+                const team = teamsData[teamKey];
+                const starters = (team?.players || []).filter(p=>(p.status||'starting')==='starting').map(p=>p.name);
+                const subs = (team?.players || []).filter(p=>p.status==='sub').map(p=>p.name);
+                const offOpts = ['<option value=""></option>', ...starters.map(p=>`<option value="${p}">${p}</option>`)];
+                const onOpts = ['<option value=""></option>', ...subs.map(p=>`<option value="${p}">${p}</option>`)];
+                playerSel.innerHTML = offOpts.join('');
+                playerOnSel.innerHTML = onOpts.join('');
             };
             const updateType = () => {
                 playerOnSel.style.display = typeSel.value === 'substitution' ? '' : 'none';
@@ -329,6 +334,15 @@ export function renderGraphicsPanel(container, eventData, mode = 'live') {
                 const timeStr = formatTime(secs);
                 const logEntry = { ts: Date.now(), type, team: teamKey==='teamA'?'a':'b', player: playerField, playerName, playerNumber, time: timeStr };
                 await addMatchLog(eventId, logEntry);
+                if(type === 'substitution'){
+                    const teamObj = teamsData[teamKey];
+                    const offIdx = teamObj.players.findIndex(p=>p.name===off);
+                    const onIdx = teamObj.players.findIndex(p=>p.name===on);
+                    if(offIdx >= 0) teamObj.players[offIdx].status = 'sub';
+                    if(onIdx >= 0) teamObj.players[onIdx].status = 'starting';
+                    if(teamsRef) await set(teamsRef, teamsData);
+                    fillPlayers();
+                }
                 const obj = {
                     id: (Date.now()+Math.random()).toString(36),
                     title: `${teamName} ${type.charAt(0).toUpperCase()+type.slice(1)}`,

--- a/wwwroot/app/js/components/introPanel.js
+++ b/wwwroot/app/js/components/introPanel.js
@@ -19,6 +19,8 @@ export function renderIntroPanel(container, eventId, onOverlayStateChange) {
     let activeIntro = {};
     let visible = false;
     let preview = false;
+    let teamsData = null;
+    let tournamentData = null;
 
     onValue(getIntroRef(eid), snap => {
         intros = snap.val() || [];
@@ -30,6 +32,8 @@ export function renderIntroPanel(container, eventId, onOverlayStateChange) {
         updateOverlayState(eid,{ holdslateSettings:introSettings });
         render();
     });
+    onValue(ref(db, `teams/${eid}`), snap => { teamsData = snap.val(); render(); });
+    onValue(ref(db, `tournament/${eid}`), snap => { tournamentData = snap.val(); render(); });
 
     listenOverlayState(eid, state => {
         activeIntro = (state && state.holdslate) || {};
@@ -45,21 +49,34 @@ export function renderIntroPanel(container, eventId, onOverlayStateChange) {
     function render(){
         const highlight = visible ? 'ring-4 ring-green-400' : preview ? 'ring-4 ring-brand' : '';
         const weatherSection = introSettings.weatherLoc ? `<div class="mb-2"><button class="control-button btn-sm" id="hs-edit-weather">Weather Graphic</button></div>` : '';
+        const teamOptions = teamsData ? (teamsData.teams ? teamsData.teams.map((t,i)=>`<option value="${i}">${t.name}</option>`).join('') : ['a','b'].map(k=>`<option value="${k}">${teamsData[k==='a'?'teamA':'teamB']?.name || ('Team '+k.toUpperCase())}</option>`).join('')) : '';
+        const formationRow = teamsData ? `<div class="flex items-center gap-2"><span class="flex-1">Formation Graphic</span><select id="formation-team" class="border p-1 flex-1">${teamOptions}</select><button class="control-button btn-sm" id="formation-preview">Preview</button><button class="control-button btn-sm" id="formation-live">Live</button><button class="control-button btn-sm" id="formation-edit">Edit</button></div>` : '';
         container.innerHTML = `
             <div class='intro-panel ${highlight}'>
                 <div class="flex items-center justify-between mb-2">
                     <h2 class="font-bold text-lg">Intro Graphics</h2>
-                    <div class="flex gap-2">
-                        <button class="control-button btn-sm" id="hs-input">Input</button>
-                        <button class="control-button btn-sm" id="hs-add">Add</button>
+                    <button class="control-button btn-sm" id="hs-input">Input data</button>
+                </div>
+                <div class="space-y-2 mb-4">
+                    <div class="flex items-center gap-2">
+                        <span class="flex-1">Show Fixtures</span>
+                        <button class="control-button btn-sm" id="fixtures-preview">Preview</button>
+                        <button class="control-button btn-sm" id="fixtures-live">Live</button>
+                        <button class="control-button btn-sm" id="fixtures-edit">Edit</button>
+                    </div>
+                    ${formationRow}
+                    <div class="flex items-center gap-2">
+                        <span class="flex-1">Course Details</span>
+                        <button class="control-button btn-sm" id="course-preview">Preview</button>
+                        <button class="control-button btn-sm" id="course-live">Live</button>
+                        <button class="control-button btn-sm" id="course-edit">Edit</button>
                     </div>
                 </div>
-                <div class="flex gap-2 mb-2">
-                    <button class="control-button btn-sm" id="hs-show-fixtures">Show Fixtures</button>
-                    <button class="control-button btn-sm" id="hs-show-formation">Formation Graphic</button>
-                    <button class="control-button btn-sm" id="hs-show-course">Course Details</button>
-                </div>
                 ${weatherSection}
+                <div class="flex items-center justify-between mb-2">
+                    <h3 class="font-bold text-md">Holdslates</h3>
+                    <button class="control-button btn-sm" id="hs-add">Add</button>
+                </div>
                 <ul class="space-y-2 mb-4">
                     ${intros.length===0 ? `<li class='text-gray-400'>No intro graphics yet.</li>` : intros.map((hs,i)=>`
                         <li class="flex items-center gap-4 bg-gray-50 rounded p-2 text-gray-900">
@@ -116,6 +133,10 @@ export function renderIntroPanel(container, eventId, onOverlayStateChange) {
                                 <input class="border p-1 w-full" name="venue" />
                             </div>
                             <div class="mb-2">
+                                <label class="block text-sm">Event Date</label>
+                                <input class="border p-1 w-full" type="date" name="eventDate" />
+                            </div>
+                            <div class="mb-2">
                                 <label class="block text-sm">Weather Location</label>
                                 <input class="border p-1 w-full" name="weatherLoc" />
                             </div>
@@ -160,15 +181,162 @@ export function renderIntroPanel(container, eventId, onOverlayStateChange) {
                         </form>
                     </div>
                 </div>
+                <div id="fixtures-modal" class="modal-overlay" style="display:none;">
+                    <div class="modal-window">
+                        <h3 class="font-bold text-lg mb-2">Fixtures</h3>
+                        <form id="fixtures-form">
+                            <div id="fixtures-list" class="mb-2"></div>
+                            <div class="mb-2">
+                                <label class="block text-sm">Style</label>
+                                <select name="style" class="border p-1 w-full">
+                                    <option value="style1">Style 1</option>
+                                    <option value="style2">Style 2</option>
+                                    <option value="style3">Style 3</option>
+                                </select>
+                            </div>
+                            <div class="mb-2">
+                                <label class="block text-sm">Transition</label>
+                                <select name="transition" class="border p-1 w-full">
+                                    <option value="fade">Fade</option>
+                                    <option value="slide">Slide</option>
+                                    <option value="wipe">Wipe</option>
+                                </select>
+                            </div>
+                            <div class="flex gap-2 mt-4">
+                                <button type="submit" class="control-button btn-sm">Save</button>
+                                <button type="button" id="fixtures-cancel" class="control-button btn-sm bg-gray-400 hover:bg-gray-600">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+                <div id="formation-modal" class="modal-overlay" style="display:none;">
+                    <div class="modal-window">
+                        <h3 class="font-bold text-lg mb-2">Formation Settings</h3>
+                        <form id="formation-form">
+                            <div class="mb-2">
+                                <label class="block text-sm">Style</label>
+                                <select name="style" class="border p-1 w-full">
+                                    <option value="style1">Style 1</option>
+                                    <option value="style2">Style 2</option>
+                                    <option value="style3">Style 3</option>
+                                </select>
+                            </div>
+                            <div class="mb-2">
+                                <label class="block text-sm">Transition</label>
+                                <select name="transition" class="border p-1 w-full">
+                                    <option value="fade">Fade</option>
+                                    <option value="slide">Slide</option>
+                                    <option value="wipe">Wipe</option>
+                                </select>
+                            </div>
+                            <div class="flex gap-2 mt-4">
+                                <button type="submit" class="control-button btn-sm">Save</button>
+                                <button type="button" id="formation-cancel" class="control-button btn-sm bg-gray-400 hover:bg-gray-600">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+                <div id="course-modal" class="modal-overlay" style="display:none;">
+                    <div class="modal-window">
+                        <h3 class="font-bold text-lg mb-2">Course Details</h3>
+                        <form id="course-form">
+                            <div class="mb-2">
+                                <label class="block text-sm">Course Name</label>
+                                <input class="border p-1 w-full" name="name" />
+                            </div>
+                            <div class="mb-2">
+                                <label class="block text-sm">Length</label>
+                                <input class="border p-1 w-full" name="length" />
+                            </div>
+                            <div class="mb-2">
+                                <label class="block text-sm">Par</label>
+                                <input class="border p-1 w-full" name="par" />
+                            </div>
+                            <div class="mb-2">
+                                <label class="block text-sm">Image URL</label>
+                                <input class="border p-1 w-full" name="image" />
+                            </div>
+                            <div class="mb-2">
+                                <label class="block text-sm">Style</label>
+                                <select name="style" class="border p-1 w-full">
+                                    <option value="style1">Style 1</option>
+                                    <option value="style2">Style 2</option>
+                                    <option value="style3">Style 3</option>
+                                </select>
+                            </div>
+                            <div class="mb-2">
+                                <label class="block text-sm">Transition</label>
+                                <select name="transition" class="border p-1 w-full">
+                                    <option value="fade">Fade</option>
+                                    <option value="slide">Slide</option>
+                                    <option value="wipe">Wipe</option>
+                                </select>
+                            </div>
+                            <div class="flex gap-2 mt-4">
+                                <button type="submit" class="control-button btn-sm">Save</button>
+                                <button type="button" id="course-cancel" class="control-button btn-sm bg-gray-400 hover:bg-gray-600">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
             </div>`;
 
+        function buildFormationData(){
+            if(!teamsData) return {};
+            const selEl = container.querySelector('#formation-team');
+            const sel = selEl ? selEl.value : 'a';
+            let teamName = '';
+            if(teamsData.teams){
+                const t = teamsData.teams[parseInt(sel,10)] || {};
+                teamName = t.name || '';
+            }else{
+                teamName = sel==='b' ? teamsData.teamB?.name || '' : teamsData.teamA?.name || '';
+            }
+            return { team: sel, teamName, style: introSettings.formation?.style || 'style1', transition: introSettings.formation?.transition || 'fade' };
+        }
+
         container.querySelector('#hs-add').onclick = () => showModal();
-        const fixturesBtn = container.querySelector('#hs-show-fixtures');
-        if(fixturesBtn) fixturesBtn.onclick = () => updateOverlayState(eid,{ fixturesVisible:true });
-        const formBtn = container.querySelector('#hs-show-formation');
-        if(formBtn) formBtn.onclick = () => updateOverlayState(eid,{ formationVisible:true });
-        const courseBtn = container.querySelector('#hs-show-course');
-        if(courseBtn) courseBtn.onclick = () => updateOverlayState(eid,{ courseVisible:true });
+
+        const fixturesPrev = container.querySelector('#fixtures-preview');
+        if(fixturesPrev) fixturesPrev.onclick = () => {
+            updateOverlayState(eid,{ fixtures: introSettings.fixtures || {}, fixturesPreviewVisible:true, fixturesVisible:false });
+            if(onOverlayStateChange) onOverlayStateChange({ fixturesPreviewVisible:true, fixtures:introSettings.fixtures });
+        };
+        const fixturesLive = container.querySelector('#fixtures-live');
+        if(fixturesLive) fixturesLive.onclick = () => {
+            updateOverlayState(eid,{ fixtures: introSettings.fixtures || {}, fixturesVisible:true, fixturesPreviewVisible:false });
+            if(onOverlayStateChange) onOverlayStateChange({ fixturesVisible:true, fixtures:introSettings.fixtures, fixturesPreviewVisible:false });
+        };
+        const fixturesEdit = container.querySelector('#fixtures-edit');
+        if(fixturesEdit) fixturesEdit.onclick = () => showFixturesModal();
+
+        const formationPrev = container.querySelector('#formation-preview');
+        if(formationPrev) formationPrev.onclick = () => {
+            const data = buildFormationData();
+            updateOverlayState(eid,{ formation:data, formationPreviewVisible:true, formationVisible:false });
+            if(onOverlayStateChange) onOverlayStateChange({ formationPreviewVisible:true, formation:data });
+        };
+        const formationLive = container.querySelector('#formation-live');
+        if(formationLive) formationLive.onclick = () => {
+            const data = buildFormationData();
+            updateOverlayState(eid,{ formation:data, formationVisible:true, formationPreviewVisible:false });
+            if(onOverlayStateChange) onOverlayStateChange({ formationVisible:true, formation:data, formationPreviewVisible:false });
+        };
+        const formationEdit = container.querySelector('#formation-edit');
+        if(formationEdit) formationEdit.onclick = () => showFormationModal();
+
+        const coursePrev = container.querySelector('#course-preview');
+        if(coursePrev) coursePrev.onclick = () => {
+            updateOverlayState(eid,{ course:introSettings.course || {}, coursePreviewVisible:true, courseVisible:false });
+            if(onOverlayStateChange) onOverlayStateChange({ coursePreviewVisible:true, course:introSettings.course });
+        };
+        const courseLive = container.querySelector('#course-live');
+        if(courseLive) courseLive.onclick = () => {
+            updateOverlayState(eid,{ course:introSettings.course || {}, courseVisible:true, coursePreviewVisible:false });
+            if(onOverlayStateChange) onOverlayStateChange({ courseVisible:true, course:introSettings.course, coursePreviewVisible:false });
+        };
+        const courseEdit = container.querySelector('#course-edit');
+        if(courseEdit) courseEdit.onclick = () => showCourseModal();
 
         container.querySelectorAll('button[data-action]').forEach(btn=>{
             const idx = parseInt(btn.getAttribute('data-idx'));
@@ -247,12 +415,14 @@ export function renderIntroPanel(container, eventId, onOverlayStateChange) {
         const form = container.querySelector('#hs-input-form');
         if(!modal || !form) return;
         form.venue.value = introSettings.venue || '';
+        form.eventDate.value = introSettings.eventDate || '';
         form.weatherLoc.value = introSettings.weatherLoc || '';
         modal.style.display='flex';
         form.onsubmit = async e=>{
             e.preventDefault();
             const data = Object.fromEntries(new FormData(form));
             introSettings.venue = data.venue || '';
+            introSettings.eventDate = data.eventDate || '';
             introSettings.weatherLoc = data.weatherLoc || '';
             await set(getIntroSettingsRef(eid), introSettings);
             await updateOverlayState(eid,{ holdslateSettings:introSettings });
@@ -294,6 +464,87 @@ export function renderIntroPanel(container, eventId, onOverlayStateChange) {
             modal.style.display='none';
         };
         form.querySelector('#hs-weather-cancel').onclick = ()=>{ modal.style.display='none'; };
+    }
+
+    function showFixturesModal(){
+        const modal = container.querySelector('#fixtures-modal');
+        const form = container.querySelector('#fixtures-form');
+        if(!modal || !form) return;
+        const listDiv = form.querySelector('#fixtures-list');
+        const existing = introSettings.fixtures?.list || [];
+        let list = [];
+        if(tournamentData && tournamentData.matches && teamsData && teamsData.teams){
+            list = tournamentData.matches.map(m=>{
+                const ta = teamsData.teams[m.teamA] || {name:'Team A'};
+                const tb = teamsData.teams[m.teamB] || {name:'Team B'};
+                return {home:ta.name, away:tb.name};
+            });
+        }else if(teamsData){
+            const ta = teamsData.teams ? teamsData.teams[0]?.name || 'Team A' : teamsData.teamA?.name || 'Team A';
+            const tb = teamsData.teams ? teamsData.teams[1]?.name || 'Team B' : teamsData.teamB?.name || 'Team B';
+            list = [{home:ta, away:tb}];
+        }
+        listDiv.innerHTML = list.map((f,i)=>{
+            const checked = !existing.length || existing.find(e=>e.home===f.home && e.away===f.away) ? 'checked' : '';
+            return `<label class="block"><input type="checkbox" data-idx="${i}" ${checked}> ${f.home} vs ${f.away}</label>`;
+        }).join('');
+        const styleSel = form.querySelector('select[name="style"]');
+        const transSel = form.querySelector('select[name="transition"]');
+        styleSel.value = introSettings.fixtures?.style || 'style1';
+        transSel.value = introSettings.fixtures?.transition || 'fade';
+        modal.style.display='flex';
+        form.onsubmit = async e=>{
+            e.preventDefault();
+            const boxes = Array.from(listDiv.querySelectorAll('input[type="checkbox"]'));
+            const selected = boxes.filter(b=>b.checked).map(b=>list[parseInt(b.dataset.idx)]);
+            introSettings.fixtures = { list:selected, style:styleSel.value, transition:transSel.value };
+            await set(getIntroSettingsRef(eid), introSettings);
+            await updateOverlayState(eid,{ holdslateSettings:introSettings });
+            modal.style.display='none';
+        };
+        form.querySelector('#fixtures-cancel').onclick = ()=>{ modal.style.display='none'; };
+    }
+
+    function showFormationModal(){
+        const modal = container.querySelector('#formation-modal');
+        const form = container.querySelector('#formation-form');
+        if(!modal || !form) return;
+        const styleSel = form.querySelector('select[name="style"]');
+        const transSel = form.querySelector('select[name="transition"]');
+        styleSel.value = introSettings.formation?.style || 'style1';
+        transSel.value = introSettings.formation?.transition || 'fade';
+        modal.style.display='flex';
+        form.onsubmit = async e=>{
+            e.preventDefault();
+            introSettings.formation = { ...(introSettings.formation||{}), style:styleSel.value, transition:transSel.value };
+            await set(getIntroSettingsRef(eid), introSettings);
+            await updateOverlayState(eid,{ holdslateSettings:introSettings });
+            modal.style.display='none';
+        };
+        form.querySelector('#formation-cancel').onclick = ()=>{ modal.style.display='none'; };
+    }
+
+    function showCourseModal(){
+        const modal = container.querySelector('#course-modal');
+        const form = container.querySelector('#course-form');
+        if(!modal || !form) return;
+        form.name.value = introSettings.course?.name || '';
+        form.length.value = introSettings.course?.length || '';
+        form.par.value = introSettings.course?.par || '';
+        form.image.value = introSettings.course?.image || '';
+        const styleSel = form.querySelector('select[name="style"]');
+        const transSel = form.querySelector('select[name="transition"]');
+        styleSel.value = introSettings.course?.style || 'style1';
+        transSel.value = introSettings.course?.transition || 'fade';
+        modal.style.display='flex';
+        form.onsubmit = async e=>{
+            e.preventDefault();
+            introSettings.course = { name:form.name.value, length:form.length.value, par:form.par.value, image:form.image.value, style:styleSel.value, transition:transSel.value };
+            await set(getIntroSettingsRef(eid), introSettings);
+            await updateOverlayState(eid,{ holdslateSettings:introSettings });
+            modal.style.display='none';
+        };
+        form.querySelector('#course-cancel').onclick = ()=>{ modal.style.display='none'; };
     }
 
     async function uploadToServer(file, path){

--- a/wwwroot/app/js/components/lineupPanel.js
+++ b/wwwroot/app/js/components/lineupPanel.js
@@ -125,8 +125,8 @@ export function renderLineupPanel(container, eventId = 'demo', sport = 'Football
                     const y = teamKey==='a'? startY - r*step : startY + r*step;
                     for(let i=0;i<count;i++){
                         const x = (i+1)/(count+1)*100;
-                        const pl = players[idx++] || {name:'',pos:'',photo:''};
-                        res.push({name:pl.name,pos:pl.pos,photo:pl.photo,x,y});
+                        const pl = players[idx++] || {name:'',number:'',pos:'',photo:''};
+                        res.push({name:pl.name,number:pl.number,pos:pl.pos,photo:pl.photo,x,y});
                     }
                 });
                 return {team:teamKey,players:res};
@@ -135,7 +135,7 @@ export function renderLineupPanel(container, eventId = 'demo', sport = 'Football
                 const team = teamKey==='a'
                     ? (teamsData.teams ? teamsData.teams[teamsData.currentA||0] : teamsData.teamA)
                     : (teamsData.teams ? teamsData.teams[teamsData.currentB||1] : teamsData.teamB);
-                return {team:teamKey, players: team.players.map(p=>({name:p.name,pos:p.pos,photo:p.photo}))};
+                return {team:teamKey, players: team.players.map(p=>({name:p.name,number:p.number,pos:p.pos,photo:p.photo}))};
             }
             function toggleFormation(teamKey){
                 if(formationVisible && formationTeam===teamKey){

--- a/wwwroot/app/js/components/profileWizard.js
+++ b/wwwroot/app/js/components/profileWizard.js
@@ -95,7 +95,7 @@ export function renderProfileWizard(container, eventData) {
         const cfg = sportsData[sport] || sportsData['Football'];
         const label = getTeamLabel(sport);
         const playerSlots = cfg.playersPerTeam + (cfg.subs || 0);
-        const players = Array.from({ length: playerSlots }).map(() => ({ name: '', pos: '' }));
+        const players = Array.from({ length: playerSlots }).map(() => ({ name: '', number: '', pos: '' }));
         const nameA = cfg.playersPerTeam === 1 ? 'Player 1' : 'Team A';
         const nameB = cfg.playersPerTeam === 1 ? 'Player 2' : 'Team B';
         const data = snap.val() || { teamA:{ name:nameA, logo:'', players: players.slice() }, teamB:{ name:nameB, logo:'', players: players.slice() } };

--- a/wwwroot/app/js/components/scoreboardPanel.js
+++ b/wwwroot/app/js/components/scoreboardPanel.js
@@ -104,6 +104,7 @@ function getScoreboardRef(eventId) {
 export function renderScoreboardPanel(container, sport = 'Football', eventId = 'demo') {
     const cfg = sportsData[sport] || sportsData['Football'];
     const scoreboardStyles = getStylesForSport(sport);
+    const goalSport = (sportsData[sport]?.logEvents || []).includes('goal');
 
     let teamsData = null;
 
@@ -152,7 +153,8 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
         (matchLogs||[]).forEach(e=>{
             if(e.type==='goal'){
                 const idx = e.team==='a'?0:1;
-                const entry = e.player ? `${e.player}${e.time?` ${e.time}`:''}` : e.time||'';
+                const assist = e.assist ? ` (${e.assist})` : '';
+                const entry = e.player ? `${e.player}${assist}${e.time?` ${e.time}`:''}` : e.time||'';
                 newScorers[idx].push(entry.trim());
             }
         });
@@ -196,6 +198,9 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
             base.dartLogs = scores.map(() => []);
         }
         base.scorers = scores.map(() => []);
+        base.extraTime = false;
+        base.showPens = false;
+        base.pens = scores.map(() => 0);
         return base;
     }
 
@@ -255,6 +260,41 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
                     </div>
                 </div>
             </div>`;
+        const parseTime = str => { const [m = '0', s = '0'] = str.split(':'); return parseInt(m) * 60 + parseInt(s); };
+        const formatTime = secs => `${Math.floor(secs/60)}:${(Math.abs(secs)%60).toString().padStart(2,'0')}`;
+        const currentTimeStr = () => {
+            const sb = getFormData();
+            let secs = parseTime(sb.time || '0:00');
+            if(sb.timerRunning && sb.timerStart){
+                const elapsed = Math.floor((Date.now()-sb.timerStart)/1000);
+                secs = (sb.timeDirection==='down') ? Math.max(0,(sb.timerBase||0) - elapsed) : (sb.timerBase||0) + elapsed;
+            }
+            return formatTime(secs);
+        };
+        async function promptGoal(teamIndex){
+            return new Promise(res=>{
+                const teamKey = teamIndex===0?'teamA':'teamB';
+                const players = (teamsData?.[teamKey]?.players||[]).filter(p=>(p.status||'starting')==='starting');
+                const opts = players.map(p=>`<option value="${p.name}">${p.name}</option>`).join('');
+                const modal = document.createElement('div');
+                modal.className = 'modal-overlay';
+                modal.innerHTML = `
+                    <div class="modal-window">
+                        <h3 class="font-bold text-lg mb-2">Goal Details</h3>
+                        <div class="mb-2"><label class="block text-sm">Scorer</label><select id="goal-scorer" class="border p-1 w-full"><option value=""></option>${opts}</select></div>
+                        <div class="mb-2"><label class="block text-sm">Assist</label><select id="goal-assist" class="border p-1 w-full"><option value=""></option>${opts}</select></div>
+                        <div class="flex gap-2 mt-4"><button id="goal-ok" class="control-button btn-sm">Save</button><button id="goal-cancel" class="control-button btn-sm bg-gray-400 hover:bg-gray-600">Cancel</button></div>
+                    </div>`;
+                container.appendChild(modal);
+                modal.querySelector('#goal-cancel').onclick = () => { modal.remove(); res(null); };
+                modal.querySelector('#goal-ok').onclick = () => {
+                    const scorer = modal.querySelector('#goal-scorer').value;
+                    const assist = modal.querySelector('#goal-assist').value;
+                    modal.remove();
+                    res({scorer,assist});
+                };
+            });
+        }
         const table = container.querySelector('#sb-table');
         const htmlParts = [];
         (data.scores || []).forEach((sc, i) => {
@@ -274,6 +314,13 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
             const dir = cfg.scoreboard.timeDirection === 'down' ? 'down' : 'up';
             htmlParts.push(`<tr><td class="pr-2">Time (${dir}):</td><td><div class="flex items-center gap-1"><input type="text" class="border p-1 w-20" id="sb-time" value="${data.time || '00:00'}" placeholder="mm:ss"><button id="sb-start" class="control-button btn-xs">Start</button><button id="sb-stop" class="control-button btn-xs">Stop</button><button id="sb-reset" class="control-button btn-xs">Reset</button></div></td></tr>`);
             htmlParts.push(`<tr><td class="pr-2">Stoppage:</td><td><div class="flex items-center gap-1"><input type="number" class="border p-1 w-12" id="sb-stoppage" value="${data.stoppage || 0}"><button id="sb-add-st" class="control-button btn-xs">+1</button><button id="sb-toggle-st" class="control-button btn-xs${data.showStoppage?' ring-2 ring-green-400':''}">Toggle</button></div></td></tr>`);
+        }
+        if(goalSport){
+            htmlParts.push(`<tr><td class="pr-2">Extra Time:</td><td><button id="sb-toggle-et" class="control-button btn-xs${data.extraTime?' ring-2 ring-green-400':''}">Toggle</button></td></tr>`);
+            htmlParts.push(`<tr><td class="pr-2">Shoot-out:</td><td><button id="sb-toggle-pens" class="control-button btn-xs${data.showPens?' ring-2 ring-green-400':''}">Toggle</button></td></tr>`);
+            if(data.showPens){
+                htmlParts.push(`<tr><td class="pr-2">Pens:</td><td><div class="flex items-center gap-1"><input type="number" id="sb-pen-0" class="border p-1 w-12 text-center" value="${data.pens?.[0]||0}"><button id="sb-pen-add-0" class="control-button btn-xs">+1</button><span class="mx-2">|</span><input type="number" id="sb-pen-1" class="border p-1 w-12 text-center" value="${data.pens?.[1]||0}"><button id="sb-pen-add-1" class="control-button btn-xs">+1</button></div></td></tr>`);
+            }
         }
         if (cfg.scoreboard.round) {
             htmlParts.push(`<tr><td class="pr-2">Round:</td><td><input type="number" class="border p-1 w-16" id="sb-round" value="${data.round || 1}"></td></tr>`);
@@ -348,7 +395,7 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
                     btn.className = 'score-btn btn-xs';
                     btn.style.background = btnCfg.color || '#666';
                     if (btnCfg.textColor) btn.style.color = btnCfg.textColor;
-                    btn.addEventListener('click', () => {
+                    btn.addEventListener('click', async () => {
                         const val = parseInt(input.value) || 0;
                         const newVal = val + btnCfg.value;
                         input.value = newVal;
@@ -362,6 +409,23 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
                                 br.value = (parseInt(br.value) || 0) + btnCfg.value;
                                 if (hb && parseInt(br.value) > (parseInt(hb.value) || 0)) hb.value = br.value;
                             }
+                        }
+                        if(goalSport && btnCfg.value === 1){
+                            const res = await promptGoal(i);
+                            if(res){
+                                const teamKey = i===0?'a':'b';
+                                const teamPlayers = getTeam(i).players || [];
+                                const scObj = teamPlayers.find(p=>p.name===res.scorer);
+                                const asObj = teamPlayers.find(p=>p.name===res.assist);
+                                await addMatchLog(eventId,{ts:Date.now(),type:'goal',team:teamKey,player:res.scorer,playerName:res.scorer,playerNumber:scObj?.number||'',assist:res.assist,assistNumber:asObj?.number||'',time:currentTimeStr()});
+                                await saveData(getFormData());
+                            }else{
+                                input.value = val;
+                                data.scores[i] = val;
+                                if (cSpan) cSpan.textContent = getCheckout(val) || '';
+                            }
+                        }else{
+                            await saveData(getFormData());
                         }
                     });
                     holder.appendChild(btn);
@@ -386,11 +450,6 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
         const startBtn = container.querySelector('#sb-start');
         const stopBtn = container.querySelector('#sb-stop');
         const resetBtn = container.querySelector('#sb-reset');
-        const parseTime = str => {
-            const [m = '0', s = '0'] = str.split(':');
-            return parseInt(m) * 60 + parseInt(s);
-        };
-        const formatTime = secs => `${Math.floor(secs/60)}:${(Math.abs(secs)%60).toString().padStart(2,'0')}`;
         const countDown = cfg.scoreboard.timeDirection === 'down';
         let baseSecs = timeInput ? parseTime(timeInput.value) : 0;
         let timerSecs = baseSecs;
@@ -469,6 +528,43 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
                 await saveData(obj);
                 await updateOverlayState(eventId,{ scoreboard: obj });
                 render(obj);
+            };
+        }
+
+        const etBtn = container.querySelector('#sb-toggle-et');
+        if(etBtn){
+            etBtn.onclick = async () => {
+                data.extraTime = !data.extraTime;
+                const obj = getFormData();
+                await saveData(obj);
+                render(obj);
+            };
+        }
+        const penBtn = container.querySelector('#sb-toggle-pens');
+        if(penBtn){
+            penBtn.onclick = async () => {
+                data.showPens = !data.showPens;
+                const obj = getFormData();
+                await saveData(obj);
+                render(obj);
+            };
+        }
+        const penAddA = container.querySelector('#sb-pen-add-0');
+        const penAddB = container.querySelector('#sb-pen-add-1');
+        if(penAddA){
+            penAddA.onclick = async () => {
+                const inp = container.querySelector('#sb-pen-0');
+                inp.value = (parseInt(inp.value)||0) + 1;
+                const obj = getFormData();
+                await saveData(obj);
+            };
+        }
+        if(penAddB){
+            penAddB.onclick = async () => {
+                const inp = container.querySelector('#sb-pen-1');
+                inp.value = (parseInt(inp.value)||0) + 1;
+                const obj = getFormData();
+                await saveData(obj);
             };
         }
 
@@ -558,6 +654,16 @@ export function renderScoreboardPanel(container, sport = 'Football', eventId = '
             if (cfg.scoreboard.highBreak) obj.highBreak = parseInt(container.querySelector('#sb-highbreak').value) || 0;
             if (cfg.scoreboard.turn) obj.turn = parseInt(container.querySelector('#sb-turn').value) || 0;
             obj.scorers = currentData.scorers || [[],[]];
+            obj.extraTime = data.extraTime || false;
+            obj.showPens = data.showPens || false;
+            if(obj.showPens){
+                obj.pens = [
+                    parseInt(container.querySelector('#sb-pen-0').value) || 0,
+                    parseInt(container.querySelector('#sb-pen-1').value) || 0
+                ];
+            }else{
+                obj.pens = data.pens || [0,0];
+            }
             if (sport === 'Darts' && data.checkoutText) {
                 obj.checkoutPlayer = data.checkoutPlayer;
                 obj.checkoutText = data.checkoutText;

--- a/wwwroot/app/js/components/socialPanel.js
+++ b/wwwroot/app/js/components/socialPanel.js
@@ -74,6 +74,7 @@ export function renderSocialPanel(container, eventId) {
               <option value="style1">Style 1</option>
               <option value="style2">Style 2</option>
               <option value="style3">Style 3</option>
+              <option value="bold">Bold</option>
             </select>
             <button id="edit-style" class="control-button btn-sm">Edit Style</button>
           </div>
@@ -135,6 +136,22 @@ export function renderSocialPanel(container, eventId) {
       } catch (e) {
         console.error(e);
         this.generating.delete(id);
+        const miss = e.message?.match(/^missing:(.+)$/);
+        if (miss) {
+          if (confirm(`Missing image: ${miss[1]}. Generate without it?`)) {
+            const opts = { ...this.styleSettings, ignoreMissing: true };
+            if (miss[1].includes('/portraits/')) opts.includePlayerPhotos = false;
+            if (miss[1].includes('/logos/')) opts.includeTeamLogos = false;
+            try {
+              const urls = await generateSocialAssets(this.eventId, id, this.templateStyle, opts);
+              await updateMatchLogEntry(this.eventId, id, { ...log, social: urls });
+            } catch (e2) {
+              alert(`Failed to generate post: ${e2.message}`);
+            }
+          }
+        } else {
+          alert(`Failed to generate post: ${e.message}`);
+        }
       }
       this.updateLogs();
       this.updatePosts();
@@ -148,7 +165,20 @@ export function renderSocialPanel(container, eventId) {
         this.finalPost = await generateFinalScoreAssets(this.eventId, this.templateStyle, this.styleSettings);
       }catch(e){
         console.error(e);
-        this.finalPost = null;
+        const miss = e.message?.match(/^missing:(.+)$/);
+        if (miss && confirm(`Missing image: ${miss[1]}. Generate without it?`)) {
+          const opts = { ...this.styleSettings, ignoreMissing: true };
+          if (miss[1].includes('/logos/')) opts.includeTeamLogos = false;
+          try {
+            this.finalPost = await generateFinalScoreAssets(this.eventId, this.templateStyle, opts);
+          } catch (e2) {
+            alert(`Failed to generate final post: ${e2.message}`);
+            this.finalPost = null;
+          }
+        } else {
+          alert(`Failed to generate final post: ${e.message}`);
+          this.finalPost = null;
+        }
       }
       this.generatingFinal = false;
       this.updatePosts();

--- a/wwwroot/app/js/components/socialPanel.js
+++ b/wwwroot/app/js/components/socialPanel.js
@@ -166,7 +166,9 @@ export function renderSocialPanel(container, eventId) {
       wrapper.className = 'border p-2';
       const header = document.createElement('div');
       header.className = 'mb-2 text-xs font-semibold';
-      header.textContent = `${l.time || ''} ${l.eventType || l.type || ''}${l.playerName ? ' - ' + l.playerName : ''}`;
+      const playerInfo = l.playerName || l.player || '';
+      const playerLabel = playerInfo ? ` - ${l.playerNumber ? '#' + l.playerNumber + ' ' : ''}${playerInfo}` : '';
+      header.textContent = `${l.time || ''} ${l.eventType || l.type || ''}${playerLabel}`;
       wrapper.appendChild(header);
       if (l.social) {
         const grid = document.createElement('div');
@@ -253,11 +255,12 @@ export function renderSocialPanel(container, eventId) {
       this.logs.forEach(l => {
         const tr = document.createElement('tr');
         tr.dataset.id = l.id;
+        const playerText = l.playerName || l.player || '';
         const cols = [
           l.time || '',
           l.team === 'a' ? 'Home' : l.team === 'b' ? 'Away' : (l.team || ''),
           l.eventType || l.type || '',
-          l.playerName || l.player || ''
+          l.playerNumber ? `#${l.playerNumber} ${playerText}` : playerText
         ];
         cols.forEach(text => {
           const td = document.createElement('td');

--- a/wwwroot/app/js/components/statsPanel.js
+++ b/wwwroot/app/js/components/statsPanel.js
@@ -17,7 +17,7 @@ export function renderStatsPanel(container, eventId = 'demo') {
     let teams = null;
     let logs = [];
     let sport = 'Football';
-    let config = { included: [] };
+    let config = { included: [], style: 'standard', position: 'bottom-center', transition: 'fade-slide' };
     let visible = false;
     let preview = false;
     let psVisible = false;
@@ -42,7 +42,19 @@ export function renderStatsPanel(container, eventId = 'demo') {
         if (!SPORT_STAT_OPTIONS[sport]) sport = 'Football';
         onValue(configRef, snap => {
             const val = snap.val();
-            if (val) config = val; else config = { included: SPORT_STAT_OPTIONS[sport].map(o => o.key) };
+            if (val) config = {
+                included: SPORT_STAT_OPTIONS[sport].map(o => o.key),
+                style: 'standard',
+                position: 'bottom-center',
+                transition: 'fade-slide',
+                ...val
+            };
+            else config = {
+                included: SPORT_STAT_OPTIONS[sport].map(o => o.key),
+                style: 'standard',
+                position: 'bottom-center',
+                transition: 'fade-slide'
+            };
             render();
         });
         render();
@@ -116,12 +128,20 @@ export function renderStatsPanel(container, eventId = 'demo') {
         const previewBtn = container.querySelector('#ms-preview');
         if (previewBtn) previewBtn.onclick = () => {
             const rows = calcRows();
-            updateOverlayState(eventId, { stat: { teamA, teamB, rows }, statPreviewVisible: true, statVisible: false });
+            updateOverlayState(eventId, {
+                stat: { teamA, teamB, rows, style: config.style, position: config.position, transition: config.transition },
+                statPreviewVisible: true,
+                statVisible: false
+            });
         };
         const liveBtn = container.querySelector('#ms-live');
         if (liveBtn) liveBtn.onclick = () => {
             const rows = calcRows();
-            updateOverlayState(eventId, { stat: { teamA, teamB, rows }, statVisible: true, statPreviewVisible: false });
+            updateOverlayState(eventId, {
+                stat: { teamA, teamB, rows, style: config.style, position: config.position, transition: config.transition },
+                statVisible: true,
+                statPreviewVisible: false
+            });
         };
         const hideBtn = container.querySelector('#ms-hide');
         if (hideBtn) hideBtn.onclick = () => updateOverlayState(eventId, { statVisible: false, statPreviewVisible: false });
@@ -144,17 +164,52 @@ export function renderStatsPanel(container, eventId = 'demo') {
 
         const modal = container.querySelector('#ms-modal');
         if (modal) {
-            modal.querySelector('#ms-form').innerHTML = (SPORT_STAT_OPTIONS[sport] || [])
-                .map(o=>`<label class="block text-sm"><input type="checkbox" name="${o.key}" ${config.included.includes(o.key)?'checked':''}/> ${o.label}</label>`)
-                .join('') +
-                `<div class="flex gap-2 mt-4"><button type="submit" class="control-button btn-sm">Save</button><button type="button" id="ms-cancel" class="control-button btn-sm bg-gray-400 hover:bg-gray-600">Cancel</button></div>`;
+            modal.querySelector('#ms-form').innerHTML =
+                (SPORT_STAT_OPTIONS[sport] || [])
+                    .map(o => `
+                        <label class="block text-sm">
+                            <input type="checkbox" name="${o.key}" ${config.included.includes(o.key) ? 'checked' : ''}/> ${o.label}
+                        </label>`)
+                    .join('') +
+                `<div class="mt-2">
+                    <label class="block text-sm">Style</label>
+                    <select name="style" class="border p-1 w-full">
+                        <option value="standard" ${config.style==='standard'?'selected':''}>Standard</option>
+                        <option value="minimal" ${config.style==='minimal'?'selected':''}>Minimal</option>
+                    </select>
+                </div>
+                <div class="mt-2">
+                    <label class="block text-sm">Position</label>
+                    <select name="position" class="border p-1 w-full">
+                        <option value="bottom-center" ${config.position==='bottom-center'?'selected':''}>Bottom Center</option>
+                        <option value="top-center" ${config.position==='top-center'?'selected':''}>Top Center</option>
+                        <option value="top-left" ${config.position==='top-left'?'selected':''}>Top Left</option>
+                        <option value="top-right" ${config.position==='top-right'?'selected':''}>Top Right</option>
+                        <option value="bottom-left" ${config.position==='bottom-left'?'selected':''}>Bottom Left</option>
+                        <option value="bottom-right" ${config.position==='bottom-right'?'selected':''}>Bottom Right</option>
+                    </select>
+                </div>
+                <div class="mt-2">
+                    <label class="block text-sm">Transition</label>
+                    <select name="transition" class="border p-1 w-full">
+                        <option value="fade-slide" ${config.transition==='fade-slide'?'selected':''}>Fade & Slide</option>
+                        <option value="none" ${config.transition==='none'?'selected':''}>None</option>
+                    </select>
+                </div>
+                <div class="flex gap-2 mt-4">
+                    <button type="submit" class="control-button btn-sm">Save</button>
+                    <button type="button" id="ms-cancel" class="control-button btn-sm bg-gray-400 hover:bg-gray-600">Cancel</button>
+                </div>`;
             const form = modal.querySelector('#ms-form');
             form.onsubmit = async e => {
                 e.preventDefault();
                 const included = Array.from(form.querySelectorAll('input[type="checkbox"]'))
                     .filter(ch=>ch.checked)
                     .map(ch=>ch.name);
-                await saveConfig({ included });
+                const style = form.style.value;
+                const position = form.position.value;
+                const transition = form.transition.value;
+                await saveConfig({ included, style, position, transition });
                 modal.style.display = 'none';
             };
             modal.querySelector('#ms-cancel').onclick = () => { modal.style.display='none'; };

--- a/wwwroot/app/js/components/stingerPanel.js
+++ b/wwwroot/app/js/components/stingerPanel.js
@@ -129,7 +129,10 @@ export function renderStingerPanel(container, eventId){
                 previewing = false;
             } else if(opt){
                 const colors = resolveColors(opt);
-                updateOverlayState(eventId,{stinger:{logo:opt.logo,text:opt.text,style:styleSel.value,colors},stingerPreviewVisible:true,stingerVisible:false});
+                const stingerData = { style: styleSel.value, colors };
+                if (opt.logo) stingerData.logo = opt.logo;
+                if (opt.text) stingerData.text = opt.text;
+                updateOverlayState(eventId,{stinger:stingerData,stingerPreviewVisible:true,stingerVisible:false});
                 previewing = true;
                 living = false;
             }
@@ -141,7 +144,10 @@ export function renderStingerPanel(container, eventId){
                 living = false;
             } else if(opt){
                 const colors = resolveColors(opt);
-                updateOverlayState(eventId,{stinger:{logo:opt.logo,text:opt.text,style:styleSel.value,colors},stingerVisible:true,stingerPreviewVisible:false});
+                const stingerData = { style: styleSel.value, colors };
+                if (opt.logo) stingerData.logo = opt.logo;
+                if (opt.text) stingerData.text = opt.text;
+                updateOverlayState(eventId,{stinger:stingerData,stingerVisible:true,stingerPreviewVisible:false});
                 living = true;
                 previewing = false;
             }

--- a/wwwroot/app/js/components/teamsPanel.js
+++ b/wwwroot/app/js/components/teamsPanel.js
@@ -31,7 +31,7 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
 
     function defaultData(){
         const count = cfg.playersPerTeam + (cfg.subs||0);
-        const players = Array.from({length:count}).map(()=>({name:'',pos:'',photo:''}));
+        const players = Array.from({length:count}).map(()=>({name:'',number:'',pos:'',photo:''}));
         const nameA = cfg.playersPerTeam === 1 ? 'Player 1' : 'Team A';
         const nameB = cfg.playersPerTeam === 1 ? 'Player 2' : 'Team B';
         if(!tournament){
@@ -45,7 +45,7 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
         const teamA = tournament ? currentData.teams[currentData.currentA||0] : currentData.teamA;
         const teamB = tournament ? currentData.teams[currentData.currentB||1] : currentData.teamB;
         const photoIcon = p=> p?'<span class="text-green-400 ml-1">✔</span>':'';
-        const list = team=>team.players.map(pl=>`<li class="flex justify-between border-b border-gray-700 py-1"><span>${pl.name}</span><span class="text-xs text-gray-400">${pl.pos}${photoIcon(pl.photo)}</span></li>`).join('');
+        const list = team=>team.players.map(pl=>`<li class="flex justify-between border-b border-gray-700 py-1"><span>${pl.number?`#${pl.number} `:''}${pl.name}</span><span class="text-xs text-gray-400">${pl.pos}${photoIcon(pl.photo)}</span></li>`).join('');
         container.innerHTML = `
             <div class='teams-panel'>
                 <h2 class="font-bold text-lg mb-2">${label}</h2>
@@ -80,7 +80,7 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
         const teamA = tournament ? currentData.teams[currentData.currentA||0] : currentData.teamA;
         const teamB = tournament ? currentData.teams[currentData.currentB||1] : currentData.teamB;
         const posOpts = cfg.positions.map(p=>`<option value="${p}">${p}</option>`).join('');
-        const rows = (prefix, team)=>team.players.map((pl,idx)=>`<tr><td><input class="border p-1 w-full" id="${prefix}-name-${idx}" value="${pl.name}"></td><td><select class="border p-1 w-full" id="${prefix}-pos-${idx}"><option value=""></option>${posOpts}</select></td><td><input class="border p-1 w-full mb-1" id="${prefix}-photo-${idx}" placeholder="Photo URL" value="${pl.photo||''}"><input type="file" id="${prefix}-file-${idx}" class="text-xs" accept="image/*"></td></tr>`).join('');
+        const rows = (prefix, team)=>team.players.map((pl,idx)=>`<tr><td><input class="border p-1 w-full" id="${prefix}-name-${idx}" value="${pl.name}"></td><td><input class="border p-1 w-12" id="${prefix}-num-${idx}" value="${pl.number||''}"></td><td><select class="border p-1 w-full" id="${prefix}-pos-${idx}"><option value=""></option>${posOpts}</select></td><td><input class="border p-1 w-full mb-1" id="${prefix}-photo-${idx}" placeholder="Photo URL" value="${pl.photo||''}"><input type="file" id="${prefix}-file-${idx}" class="text-xs" accept="image/*"></td></tr>`).join('');
         const nameALabel = cfg.playersPerTeam === 1 ? 'Player 1 Name' : 'Team A Name';
         const nameBLabel = cfg.playersPerTeam === 1 ? 'Player 2 Name' : 'Team B Name';
         return `
@@ -126,6 +126,7 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
             const slots = cfg.playersPerTeam + (cfg.subs||0);
             const getPlayers = prefix => Array.from({length:slots}).map((_,i)=>({
                 name: win.querySelector(`#${prefix}-name-${i}`).value,
+                number: win.querySelector(`#${prefix}-num-${i}`).value,
                 pos: win.querySelector(`#${prefix}-pos-${i}`).value,
                 photo: win.querySelector(`#${prefix}-photo-${i}`).value
             }));

--- a/wwwroot/app/js/components/teamsPanel.js
+++ b/wwwroot/app/js/components/teamsPanel.js
@@ -101,21 +101,43 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
         const teamA = tournament ? currentData.teams[currentData.currentA||0] : currentData.teamA;
         const teamB = tournament ? currentData.teams[currentData.currentB||1] : currentData.teamB;
         const posOpts = cfg.positions.map(p=>`<option value="${p}">${p}</option>`).join('');
-        const rows = (prefix, team)=>team.players.map((pl,idx)=>`<tr><td><input class="border p-1 w-full" id="${prefix}-name-${idx}" value="${pl.name}"></td><td><input class="border p-1 w-12" id="${prefix}-num-${idx}" value="${pl.number||''}"></td><td><select class="border p-1 w-full" id="${prefix}-pos-${idx}"><option value=""></option>${posOpts}</select></td><td><select class="border p-1 w-full" id="${prefix}-status-${idx}"><option value="starting" ${pl.status==='starting'? 'selected':''}>Starting</option><option value="sub" ${pl.status==='sub'? 'selected':''}>Sub</option><option value="not" ${pl.status==='not'? 'selected':''}>Not playing</option></select></td><td><input class="border p-1 w-full mb-1" id="${prefix}-photo-${idx}" placeholder="Photo URL" value="${pl.photo||''}"><input type="file" id="${prefix}-file-${idx}" class="text-xs" accept="image/*"></td></tr>`).join('');
+        const rowTpl = (prefix, pl) => `
+            <tr draggable="true" data-status="${pl.status}" data-prefix="${prefix}">
+                <td><input data-field="name" class="border p-1 w-full" value="${pl.name}"></td>
+                <td><input data-field="num" class="border p-1 w-12" value="${pl.number||''}"></td>
+                <td><select data-field="pos" class="border p-1 w-full"><option value=""></option>${posOpts}</select></td>
+                <td><select data-field="status" class="border p-1 w-full"><option value="starting">Starting</option><option value="sub">Sub</option><option value="not">Not playing</option></select></td>
+                <td><input data-field="photo" class="border p-1 w-full mb-1" placeholder="Photo URL" value="${pl.photo||''}"><input type="file" data-field="file" class="text-xs" accept="image/*"></td>
+            </tr>`;
         const nameALabel = cfg.playersPerTeam === 1 ? 'Player 1 Name' : 'Team A Name';
         const nameBLabel = cfg.playersPerTeam === 1 ? 'Player 2 Name' : 'Team B Name';
+        const buildRows = (prefix, team) => team.players.map(pl=>rowTpl(prefix, pl)).join('');
         return `
             <h3 class="font-bold text-lg mb-2">Edit ${label}</h3>
             <div class="flex gap-4 text-sm mb-4">
                 <div class="flex-1 min-w-0">
                     <label class="block text-sm mb-1">${nameALabel}</label>
                     <input class="border p-1 w-full mb-2" id="team-a-name" value="${teamA.name}">
-                    <table class="w-full text-xs mb-2"><tbody>${rows('a', teamA)}</tbody></table>
+                    <div class="flex gap-2 mb-2">
+                        <button id="a-show-start" class="control-button btn-xs">Starters</button>
+                        <button id="a-show-bench" class="control-button btn-xs">Bench</button>
+                        <button id="a-import" class="control-button btn-xs">Import CSV</button>
+                        <button id="a-export" class="control-button btn-xs">Export CSV</button>
+                        <input type="file" accept=".csv" id="a-csv" class="hidden">
+                    </div>
+                    <table class="w-full text-xs mb-2"><tbody id="a-body">${buildRows('a',teamA)}</tbody></table>
                 </div>
                 <div class="flex-1 min-w-0">
                     <label class="block text-sm mb-1">${nameBLabel}</label>
                     <input class="border p-1 w-full mb-2" id="team-b-name" value="${teamB.name}">
-                    <table class="w-full text-xs mb-2"><tbody>${rows('b', teamB)}</tbody></table>
+                    <div class="flex gap-2 mb-2">
+                        <button id="b-show-start" class="control-button btn-xs">Starters</button>
+                        <button id="b-show-bench" class="control-button btn-xs">Bench</button>
+                        <button id="b-import" class="control-button btn-xs">Import CSV</button>
+                        <button id="b-export" class="control-button btn-xs">Export CSV</button>
+                        <input type="file" accept=".csv" id="b-csv" class="hidden">
+                    </div>
+                    <table class="w-full text-xs mb-2"><tbody id="b-body">${buildRows('b',teamB)}</tbody></table>
                 </div>
             </div>
             <div class="flex gap-2 mt-4">
@@ -129,29 +151,111 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
         const bIdx = tournament ? (currentData.currentB||1) : null;
         const tA = tournament ? currentData.teams[aIdx] : currentData.teamA;
         const tB = tournament ? currentData.teams[bIdx] : currentData.teamB;
-        tA.players.forEach((pl,i)=>{ const sel=win.querySelector(`#a-pos-${i}`); if(sel) sel.value=pl.pos; const st=win.querySelector(`#a-status-${i}`); if(st) st.value=pl.status||'not'; });
-        tB.players.forEach((pl,i)=>{ const sel=win.querySelector(`#b-pos-${i}`); if(sel) sel.value=pl.pos; const st=win.querySelector(`#b-status-${i}`); if(st) st.value=pl.status||'not'; });
-        win.querySelectorAll('input[type="file"]').forEach(inp=>{
-            inp.addEventListener('change', async ()=>{
-                const [teamKey,,idx] = inp.id.split('-');
-                const file = inp.files[0];
-                if(file){
-                    const path = `uploads/${eventId}/teams/${teamKey}_${idx}_${file.name}`;
-                    const url = await uploadToServer(file, path);
-                    if(url) win.querySelector(`#${teamKey}-photo-${idx}`).value = url;
-                }
+        const posOpts = cfg.positions.map(p=>`<option value="${p}">${p}</option>`).join('');
+
+        function renderBody(prefix, team){
+            const body = win.querySelector(`#${prefix}-body`);
+            body.innerHTML = team.players.map(pl=>`
+                <tr draggable="true" data-status="${pl.status}" data-prefix="${prefix}">
+                    <td><input data-field="name" class="border p-1 w-full" value="${pl.name}"></td>
+                    <td><input data-field="num" class="border p-1 w-12" value="${pl.number||''}"></td>
+                    <td><select data-field="pos" class="border p-1 w-full"><option value=""></option>${posOpts}</select></td>
+                    <td><select data-field="status" class="border p-1 w-full"><option value="starting">Starting</option><option value="sub">Sub</option><option value="not">Not playing</option></select></td>
+                    <td><input data-field="photo" class="border p-1 w-full mb-1" placeholder="Photo URL" value="${pl.photo||''}"><input type="file" data-field="file" class="text-xs" accept="image/*"></td>
+                </tr>`).join('');
+            body.querySelectorAll('tr').forEach((tr,i)=>{
+                const p = team.players[i];
+                const posSel = tr.querySelector('select[data-field="pos"]');
+                if(posSel) posSel.value = p.pos || '';
+                const stSel = tr.querySelector('select[data-field="status"]');
+                if(stSel) stSel.value = p.status || 'not';
+                const fileInp = tr.querySelector('input[data-field="file"]');
+                fileInp.addEventListener('change', async ()=>{
+                    const file = fileInp.files[0];
+                    if(file){
+                        const path = `uploads/${eventId}/teams/${prefix}_${i}_${file.name}`;
+                        const url = await uploadToServer(file, path);
+                        if(url) tr.querySelector('input[data-field="photo"]').value = url;
+                    }
+                });
+                tr.addEventListener('dragstart', e=>{ dragSrc = tr; e.dataTransfer.effectAllowed='move'; });
+                tr.addEventListener('dragover', e=>{ e.preventDefault(); });
+                tr.addEventListener('drop', e=>{
+                    e.preventDefault();
+                    if(dragSrc!==tr){
+                        const tb = tr.parentNode;
+                        const children = Array.from(tb.children);
+                        const srcIdx = children.indexOf(dragSrc);
+                        const destIdx = children.indexOf(tr);
+                        if(srcIdx<destIdx) tb.insertBefore(dragSrc, tr.nextSibling); else tb.insertBefore(dragSrc, tr);
+                    }
+                });
+                stSel.addEventListener('change', ()=>{ tr.dataset.status = stSel.value; });
             });
-        });
+        }
+
+        let dragSrc = null;
+        renderBody('a', tA);
+        renderBody('b', tB);
+
+        function filterRows(prefix, status){
+            const body = win.querySelector(`#${prefix}-body`);
+            body.querySelectorAll('tr').forEach(tr=>{ tr.style.display = tr.dataset.status===status ? '' : 'none'; });
+        }
+        win.querySelector('#a-show-start').onclick = ()=>filterRows('a','starting');
+        win.querySelector('#a-show-bench').onclick = ()=>filterRows('a','sub');
+        win.querySelector('#b-show-start').onclick = ()=>filterRows('b','starting');
+        win.querySelector('#b-show-bench').onclick = ()=>filterRows('b','sub');
+
+        function getPlayers(prefix){
+            return Array.from(win.querySelectorAll(`#${prefix}-body tr`)).map(tr=>({
+                name: tr.querySelector('input[data-field="name"]').value,
+                number: tr.querySelector('input[data-field="num"]').value,
+                pos: tr.querySelector('select[data-field="pos"]').value,
+                status: tr.querySelector('select[data-field="status"]').value,
+                photo: tr.querySelector('input[data-field="photo"]').value
+            }));
+        }
+
+        function importCsv(prefix, team){
+            const inp = win.querySelector(`#${prefix}-csv`);
+            inp.addEventListener('change', e=>{
+                const file = e.target.files[0];
+                if(!file) return;
+                const reader = new FileReader();
+                reader.onload = ev=>{
+                    const lines = ev.target.result.split(/\r?\n/).filter(Boolean);
+                    const players = lines.map(line=>{
+                        const [name='',number='',pos='',status='starting',photo=''] = line.split(',');
+                        return {name,number,pos,status,photo};
+                    });
+                    team.players = players.concat(team.players.slice(players.length));
+                    renderBody(prefix, team);
+                };
+                reader.readAsText(file);
+            });
+        }
+        importCsv('a', tA);
+        importCsv('b', tB);
+
+        function exportCsv(prefix){
+            const players = getPlayers(prefix);
+            const csv = players.map(p=>[p.name,p.number,p.pos,p.status,p.photo].join(',')).join('\n');
+            const blob = new Blob([csv],{type:'text/csv'});
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `${prefix}-squad.csv`;
+            a.click();
+            URL.revokeObjectURL(url);
+        }
+        win.querySelector('#a-import').onclick = ()=>win.querySelector('#a-csv').click();
+        win.querySelector('#b-import').onclick = ()=>win.querySelector('#b-csv').click();
+        win.querySelector('#a-export').onclick = ()=>exportCsv('a');
+        win.querySelector('#b-export').onclick = ()=>exportCsv('b');
+
         win.querySelector('#teams-modal-cancel').onclick = ()=>{ modal.style.display='none'; };
         win.querySelector('#teams-modal-save').onclick = async ()=>{
-            const slots = cfg.playersPerTeam + (cfg.subs||0);
-            const getPlayers = prefix => Array.from({length:slots}).map((_,i)=>({
-                name: win.querySelector(`#${prefix}-name-${i}`).value,
-                number: win.querySelector(`#${prefix}-num-${i}`).value,
-                pos: win.querySelector(`#${prefix}-pos-${i}`).value,
-                status: win.querySelector(`#${prefix}-status-${i}`).value,
-                photo: win.querySelector(`#${prefix}-photo-${i}`).value
-            }));
             const aPlayers = getPlayers('a');
             const bPlayers = getPlayers('b');
             if(aPlayers.filter(p=>p.status==='starting').length !== cfg.playersPerTeam || bPlayers.filter(p=>p.status==='starting').length !== cfg.playersPerTeam){

--- a/wwwroot/app/js/components/teamsPanel.js
+++ b/wwwroot/app/js/components/teamsPanel.js
@@ -1,5 +1,6 @@
 import { ref, set, onValue } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js";
 import { getDatabaseInstance } from "../firebaseApp.js";
+import { listenMatchLog } from "../firebase.js";
 import { sportsData, getTeamLabel } from "../sportsConfig.js";
 
 const db = getDatabaseInstance();
@@ -27,11 +28,19 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
     const cfg = sportsData[sport] || sportsData['Football'];
     const label = getTeamLabel(sport);
     let currentData = null;
+    let matchLogs = [];
     onValue(getTeamsRef(eventId), snap=>{ currentData = snap.val() || defaultData(); renderList(); });
+    listenMatchLog(eventId, logs=>{ matchLogs = logs || []; renderList(); });
 
     function defaultData(){
         const count = cfg.playersPerTeam + (cfg.subs||0);
-        const players = Array.from({length:count}).map(()=>({name:'',number:'',pos:'',photo:''}));
+        const players = Array.from({length:count}).map((_,i)=>({
+            name:'',
+            number:'',
+            pos:'',
+            photo:'',
+            status: i < cfg.playersPerTeam ? 'starting' : 'sub'
+        }));
         const nameA = cfg.playersPerTeam === 1 ? 'Player 1' : 'Team A';
         const nameB = cfg.playersPerTeam === 1 ? 'Player 2' : 'Team B';
         if(!tournament){
@@ -45,7 +54,19 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
         const teamA = tournament ? currentData.teams[currentData.currentA||0] : currentData.teamA;
         const teamB = tournament ? currentData.teams[currentData.currentB||1] : currentData.teamB;
         const photoIcon = p=> p?'<span class="text-green-400 ml-1">✔</span>':'';
-        const list = team=>team.players.map(pl=>`<li class="flex justify-between border-b border-gray-700 py-1"><span>${pl.number?`#${pl.number} `:''}${pl.name}</span><span class="text-xs text-gray-400">${pl.pos}${photoIcon(pl.photo)}</span></li>`).join('');
+        const cardMark = (name, key) => {
+            const t = key === 'teamA' ? 'a' : 'b';
+            const hasY = matchLogs.some(l=>l.team===t && l.playerName===name && l.type==='yellow card');
+            const hasR = matchLogs.some(l=>l.team===t && l.playerName===name && l.type==='red card');
+            let m = '';
+            if(hasY) m += '<span class="ml-1 text-yellow-400">Y</span>';
+            if(hasR) m += '<span class="ml-1 text-red-500">R</span>';
+            return m;
+        };
+        const list = (team,key)=>team.players.filter(pl=>pl.status!=='not').map(pl=>{
+            const sub = pl.status==='sub' ? ' <span class="text-xs">(sub)</span>' : '';
+            return `<li class="flex justify-between border-b border-gray-700 py-1"><span>${pl.number?`#${pl.number} `:''}${pl.name}${sub}</span><span class="text-xs text-gray-400">${pl.pos}${cardMark(pl.name,key)}${photoIcon(pl.photo)}</span></li>`;
+        }).join('');
         container.innerHTML = `
             <div class='teams-panel'>
                 <h2 class="font-bold text-lg mb-2">${label}</h2>
@@ -80,7 +101,7 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
         const teamA = tournament ? currentData.teams[currentData.currentA||0] : currentData.teamA;
         const teamB = tournament ? currentData.teams[currentData.currentB||1] : currentData.teamB;
         const posOpts = cfg.positions.map(p=>`<option value="${p}">${p}</option>`).join('');
-        const rows = (prefix, team)=>team.players.map((pl,idx)=>`<tr><td><input class="border p-1 w-full" id="${prefix}-name-${idx}" value="${pl.name}"></td><td><input class="border p-1 w-12" id="${prefix}-num-${idx}" value="${pl.number||''}"></td><td><select class="border p-1 w-full" id="${prefix}-pos-${idx}"><option value=""></option>${posOpts}</select></td><td><input class="border p-1 w-full mb-1" id="${prefix}-photo-${idx}" placeholder="Photo URL" value="${pl.photo||''}"><input type="file" id="${prefix}-file-${idx}" class="text-xs" accept="image/*"></td></tr>`).join('');
+        const rows = (prefix, team)=>team.players.map((pl,idx)=>`<tr><td><input class="border p-1 w-full" id="${prefix}-name-${idx}" value="${pl.name}"></td><td><input class="border p-1 w-12" id="${prefix}-num-${idx}" value="${pl.number||''}"></td><td><select class="border p-1 w-full" id="${prefix}-pos-${idx}"><option value=""></option>${posOpts}</select></td><td><select class="border p-1 w-full" id="${prefix}-status-${idx}"><option value="starting" ${pl.status==='starting'? 'selected':''}>Starting</option><option value="sub" ${pl.status==='sub'? 'selected':''}>Sub</option><option value="not" ${pl.status==='not'? 'selected':''}>Not playing</option></select></td><td><input class="border p-1 w-full mb-1" id="${prefix}-photo-${idx}" placeholder="Photo URL" value="${pl.photo||''}"><input type="file" id="${prefix}-file-${idx}" class="text-xs" accept="image/*"></td></tr>`).join('');
         const nameALabel = cfg.playersPerTeam === 1 ? 'Player 1 Name' : 'Team A Name';
         const nameBLabel = cfg.playersPerTeam === 1 ? 'Player 2 Name' : 'Team B Name';
         return `
@@ -108,8 +129,8 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
         const bIdx = tournament ? (currentData.currentB||1) : null;
         const tA = tournament ? currentData.teams[aIdx] : currentData.teamA;
         const tB = tournament ? currentData.teams[bIdx] : currentData.teamB;
-        tA.players.forEach((pl,i)=>{ const sel=win.querySelector(`#a-pos-${i}`); if(sel) sel.value=pl.pos; });
-        tB.players.forEach((pl,i)=>{ const sel=win.querySelector(`#b-pos-${i}`); if(sel) sel.value=pl.pos; });
+        tA.players.forEach((pl,i)=>{ const sel=win.querySelector(`#a-pos-${i}`); if(sel) sel.value=pl.pos; const st=win.querySelector(`#a-status-${i}`); if(st) st.value=pl.status||'not'; });
+        tB.players.forEach((pl,i)=>{ const sel=win.querySelector(`#b-pos-${i}`); if(sel) sel.value=pl.pos; const st=win.querySelector(`#b-status-${i}`); if(st) st.value=pl.status||'not'; });
         win.querySelectorAll('input[type="file"]').forEach(inp=>{
             inp.addEventListener('change', async ()=>{
                 const [teamKey,,idx] = inp.id.split('-');
@@ -128,18 +149,25 @@ export function renderTeamsPanel(container, eventId, sport='Football', tournamen
                 name: win.querySelector(`#${prefix}-name-${i}`).value,
                 number: win.querySelector(`#${prefix}-num-${i}`).value,
                 pos: win.querySelector(`#${prefix}-pos-${i}`).value,
+                status: win.querySelector(`#${prefix}-status-${i}`).value,
                 photo: win.querySelector(`#${prefix}-photo-${i}`).value
             }));
+            const aPlayers = getPlayers('a');
+            const bPlayers = getPlayers('b');
+            if(aPlayers.filter(p=>p.status==='starting').length !== cfg.playersPerTeam || bPlayers.filter(p=>p.status==='starting').length !== cfg.playersPerTeam){
+                alert(`Each team must have exactly ${cfg.playersPerTeam} starting players.`);
+                return;
+            }
             let newData;
             if(tournament){
                 const teams = currentData.teams.slice();
-                teams[aIdx] = { ...tA, name: win.querySelector('#team-a-name').value, players: getPlayers('a') };
-                teams[bIdx] = { ...tB, name: win.querySelector('#team-b-name').value, players: getPlayers('b') };
+                teams[aIdx] = { ...tA, name: win.querySelector('#team-a-name').value, players: aPlayers };
+                teams[bIdx] = { ...tB, name: win.querySelector('#team-b-name').value, players: bPlayers };
                 newData = { ...currentData, teams };
             }else{
                 newData = {
-                    teamA: { ...tA, name: win.querySelector('#team-a-name').value, players: getPlayers('a') },
-                    teamB: { ...tB, name: win.querySelector('#team-b-name').value, players: getPlayers('b') },
+                    teamA: { ...tA, name: win.querySelector('#team-a-name').value, players: aPlayers },
+                    teamB: { ...tB, name: win.querySelector('#team-b-name').value, players: bPlayers },
                     showPhotosFormation: currentData.showPhotosFormation,
                     showPhotosStats: currentData.showPhotosStats,
                     showPhotosSubs: currentData.showPhotosSubs

--- a/wwwroot/app/js/graphicsEngine.js
+++ b/wwwroot/app/js/graphicsEngine.js
@@ -8,19 +8,19 @@ export async function renderSocialImage({ templateStyle, aspect, data, size, opt
   const ctx = canvas.getContext('2d');
   const nodes = SOCIAL_TEMPLATES[templateStyle]?.[aspect] || [];
   for (const node of nodes) {
-    await drawNode(ctx, node, data, w, h);
+    await drawNode(ctx, node, data, w, h, options);
   }
   return await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.9 });
 }
 
-async function drawNode(ctx, node, data, w, h) {
+async function drawNode(ctx, node, data, w, h, options) {
   if (node.mask) {
     ctx.save();
-    await drawNode(ctx, node.mask, data, w, h);
+    await drawNode(ctx, node.mask, data, w, h, options);
     ctx.globalCompositeOperation = 'source-in';
     const copy = { ...node };
     delete copy.mask;
-    await drawNode(ctx, copy, data, w, h);
+    await drawNode(ctx, copy, data, w, h, options);
     ctx.restore();
     return;
   }
@@ -34,7 +34,10 @@ async function drawNode(ctx, node, data, w, h) {
       ctx.fillRect(x, y, width, height);
       break;
     case 'image':
-      const img = await loadImage(resolve(node.src, data));
+      const src = resolve(node.src, data);
+      if (!src) break;
+      const img = await loadImage(src, options?.ignoreMissing);
+      if (!img) break;
       let dw = width, dh = height;
       if (node.mode === 'cover' || node.mode === 'contain') {
         const ratio = img.width / img.height;
@@ -77,13 +80,13 @@ function resolve(val, data) {
   return data[val] || val;
 }
 
-function loadImage(src) {
+function loadImage(src, ignoreMissing) {
   if (!IMG_CACHE.has(src)) {
     IMG_CACHE.set(src, new Promise((res, rej) => {
       const img = new Image();
       img.crossOrigin = 'anonymous';
       img.onload = () => res(img);
-      img.onerror = rej;
+      img.onerror = () => ignoreMissing ? res(null) : rej(new Error(`missing:${src}`));
       img.src = src;
     }));
   }

--- a/wwwroot/app/js/main-commentator.js
+++ b/wwwroot/app/js/main-commentator.js
@@ -57,8 +57,8 @@ function buildFormation(key){
         const y = key==='a'? startY - r*step : startY + r*step;
         for(let i=0;i<count;i++){
             const x = (i+1)/(count+1)*100;
-            const pl = players[idx++] || {name:'',pos:'',photo:''};
-            res.push({name:pl.name,pos:pl.pos,photo:pl.photo,x,y});
+            const pl = players[idx++] || {name:'',number:'',pos:'',photo:''};
+            res.push({name:pl.name,number:pl.number,pos:pl.pos,photo:pl.photo,x,y});
         }
     });
     return res;
@@ -117,7 +117,7 @@ function renderTeamColumn(key){
     const showPhoto = teams.showPhotosFormation;
     const formHtml = formation.length ? `<div class='relative w-full' style='padding-top:60%;'>
             <div class='formation-pitch'></div>
-            ${formation.map(pl=>`<div class='formation-player' style='top:${pl.y}%;left:${pl.x}%;'>${showPhoto && pl.photo?`<img src='${pl.photo}' class='formation-photo'>`:''}<span>${pl.name}</span></div>`).join('')}
+            ${formation.map(pl=>`<div class='formation-player' style='top:${pl.y}%;left:${pl.x}%;'>${showPhoto && pl.photo?`<img src='${pl.photo}' class='formation-photo'>`:''}<span>${pl.number?`#${pl.number} `:''}${pl.name}</span>${pl.pos?`<div class='text-xs'>${pl.pos}</div>`:''}</div>`).join('')}
         </div>` : '<div class="text-gray-400">No formation</div>';
     const statsHtml = statsList.length ? `<ul class='list-disc list-inside text-sm space-y-1'>${statsList.map(s=>`<li>${s.fact}${s.player?` - ${s.player}`:''}</li>`).join('')}</ul>` : '<div class="text-gray-400">No stats</div>';
     const logHtml = logList.length ? `<ul class='text-sm space-y-1'>${logList.map(e=>`<li>${e.time||''} ${e.type||''} ${e.player||''}</li>`).join('')}</ul>` : '<div class="text-gray-400">No log</div>';

--- a/wwwroot/app/js/main-overlay.js
+++ b/wwwroot/app/js/main-overlay.js
@@ -834,7 +834,9 @@ function renderOverlayFromFirebase(state, graphics, branding) {
         formOverlay.innerHTML = `<div class='formation-pitch'></div>` +
             formData.players.map(p=>{
                 const photo = showPhoto && p.photo ? `<img src='${p.photo}' class='formation-photo'>` : '';
-                return `<div class='formation-player' style='top:${p.y}%;left:${p.x}%;font-family:${branding.font};'>${photo}<span>${p.name}</span></div>`;
+                const num = p.number ? `#${p.number} ` : '';
+                const pos = p.pos ? `<div class='text-xs'>${p.pos}</div>` : '';
+                return `<div class='formation-player' style='top:${p.y}%;left:${p.x}%;font-family:${branding.font};'>${photo}<span>${num}${p.name}</span>${pos}</div>`;
             }).join('') + bottomImg;
         if(!prevFormationVisible){
             if(bottomSp) addSponsorLog(eventId,{ts:Date.now(),placement:'formationBottom',sponsor:sponsorPlacements.formationBottom,action:'show'});

--- a/wwwroot/app/js/main-overlay.js
+++ b/wwwroot/app/js/main-overlay.js
@@ -627,7 +627,10 @@ function renderOverlayFromFirebase(state, graphics, branding) {
         }
         const info = [];
         if (timeStr) info.push(timeStr);
-        if (scoreboardData.period) info.push('P' + scoreboardData.period);
+        if (scoreboardData.period) {
+            if(scoreboardData.extraTime && scoreboardData.period > 2) info.push('ET' + (scoreboardData.period - 2));
+            else info.push('P' + scoreboardData.period);
+        }
         if (scoreboardData.round) info.push('R' + scoreboardData.round);
         if (scoreboardData.sets) info.push('Sets ' + scoreboardData.sets.join('-'));
         if (scoreboardData.games) info.push('Games ' + scoreboardData.games.join('-'));
@@ -642,6 +645,11 @@ function renderOverlayFromFirebase(state, graphics, branding) {
         if (scoreboardData.points) info.push('Pts ' + scoreboardData.points.join('-'));
         if (scoreboardData.overs) info.push('Ov ' + scoreboardData.overs.join('-'));
         if (scoreboardData.wickets) info.push('Wk ' + scoreboardData.wickets.join('-'));
+        if (scoreboardData.showPens) {
+            const pA = scoreboardData.pens?.[0] ?? 0;
+            const pB = scoreboardData.pens?.[1] ?? 0;
+            info.push('Pens ' + pA + '-' + pB);
+        }
         const infoHtml = info.length ? `<div class='sb-info'>${info.join(' | ')}</div>` : '';
         const brand = branding.primaryColor || '#e16316';
         const textA = contrastColor(colors[0]);
@@ -690,6 +698,7 @@ function renderOverlayFromFirebase(state, graphics, branding) {
         } else if(style==='football' || style.startsWith('football-')){
             const timePart = timeStr ? `<span class="sb-time">${timeStr}</span>` : '';
             const stopPart = scoreboardData.showStoppage && scoreboardData.stoppage ? `<span class="sb-time">+${scoreboardData.stoppage}</span>` : '';
+            const pensPart = scoreboardData.showPens ? `<span class=\"sb-time\">Pens ${scoreboardData.pens?.[0]||0}-${scoreboardData.pens?.[1]||0}</span>` : '';
             scoreboardOverlay.innerHTML = `
             ${topImg}
             <div class="sb-row">
@@ -698,6 +707,7 @@ function renderOverlayFromFirebase(state, graphics, branding) {
                 <span class="sb-team${aClassB}" style="background:${colors[1]};color:${textB}">${showLogos ? `<img src='${logos[1]}' class='sb-team-logo'>` : ''}${names[1]}</span>
                 ${timePart}
                 ${stopPart}
+                ${pensPart}
             </div>
             ${sbSponsorHtml}
             ${bottomImg}`;

--- a/wwwroot/app/js/main-overlay.js
+++ b/wwwroot/app/js/main-overlay.js
@@ -461,7 +461,9 @@ function renderOverlayFromFirebase(state, graphics, branding) {
 
     // Fixtures Overlay
     let fixturesOverlay = overlayContainer.querySelector('#fixtures-overlay');
-    if (state && state.fixturesVisible) {
+    const fixturesData = state && state.fixtures;
+    const fixturesShow = previewMode ? state && state.fixturesPreviewVisible : state && state.fixturesVisible;
+    if (fixturesShow && fixturesData) {
         if (!fixturesOverlay) {
             fixturesOverlay = document.createElement('div');
             fixturesOverlay.id = 'fixtures-overlay';
@@ -479,14 +481,18 @@ function renderOverlayFromFirebase(state, graphics, branding) {
         fixturesOverlay.style.justifyContent = 'center';
         fixturesOverlay.style.zIndex = '110';
         fixturesOverlay.style.fontFamily = branding.font;
-        fixturesOverlay.innerHTML = '<div style="font-size:3rem;">Fixtures coming soon</div>';
+        fixturesOverlay.style.opacity = previewMode ? '0.6' : '1';
+        const listHtml = (fixturesData.list||[]).map(f=>`<div>${f.home} vs ${f.away}</div>`).join('');
+        fixturesOverlay.innerHTML = `<div style="font-size:3rem;text-align:center;">${listHtml || 'No fixtures'}</div>`;
     } else if (fixturesOverlay) {
         fixturesOverlay.remove();
     }
 
     // Formation Overlay
     let formationOverlay = overlayContainer.querySelector('#formation-overlay');
-    if (state && state.formationVisible) {
+    const formationData = state && state.formation;
+    const formationShow = previewMode ? state && state.formationPreviewVisible : state && state.formationVisible;
+    if (formationShow && formationData) {
         if (!formationOverlay) {
             formationOverlay = document.createElement('div');
             formationOverlay.id = 'formation-overlay';
@@ -504,14 +510,17 @@ function renderOverlayFromFirebase(state, graphics, branding) {
         formationOverlay.style.justifyContent = 'center';
         formationOverlay.style.zIndex = '110';
         formationOverlay.style.fontFamily = branding.font;
-        formationOverlay.innerHTML = '<div style="font-size:3rem;">Formation graphic</div>';
+        formationOverlay.style.opacity = previewMode ? '0.6' : '1';
+        formationOverlay.innerHTML = `<div style="font-size:3rem;">${formationData.teamName || 'Formation graphic'}</div>`;
     } else if (formationOverlay) {
         formationOverlay.remove();
     }
 
     // Course Overlay
     let courseOverlay = overlayContainer.querySelector('#course-overlay');
-    if (state && state.courseVisible) {
+    const courseData = state && state.course;
+    const courseShow = previewMode ? state && state.coursePreviewVisible : state && state.courseVisible;
+    if (courseShow && courseData) {
         if (!courseOverlay) {
             courseOverlay = document.createElement('div');
             courseOverlay.id = 'course-overlay';
@@ -529,7 +538,8 @@ function renderOverlayFromFirebase(state, graphics, branding) {
         courseOverlay.style.justifyContent = 'center';
         courseOverlay.style.zIndex = '110';
         courseOverlay.style.fontFamily = branding.font;
-        courseOverlay.innerHTML = '<div style="font-size:3rem;">Course details</div>';
+        courseOverlay.style.opacity = previewMode ? '0.6' : '1';
+        courseOverlay.innerHTML = `<div style="font-size:3rem;text-align:center;">${courseData.name || 'Course details'}</div>`;
     } else if (courseOverlay) {
         courseOverlay.remove();
     }

--- a/wwwroot/app/js/main-overlay.js
+++ b/wwwroot/app/js/main-overlay.js
@@ -920,14 +920,44 @@ function renderOverlayFromFirebase(state, graphics, branding) {
             overlayContainer.appendChild(statOverlay);
         }
         statOverlay.style.position = 'absolute';
-        statOverlay.style.bottom = '2rem';
-        statOverlay.style.left = '50%';
-        statOverlay.style.transform = 'translateX(-50%)';
         statOverlay.style.fontFamily = branding.font;
         statOverlay.style.opacity = previewMode ? '0.6' : '1';
-        const head = `<thead><tr><th></th><th>${statData.teamA}</th><th>${statData.teamB}</th></tr></thead>`;
-        const body = `<tbody>${statData.rows.map(r=>`<tr><td>${r.label}</td><td>${r.a}</td><td>${r.b}</td></tr>`).join('')}</tbody>`;
-        statOverlay.innerHTML = `<div class='stats-box'><table>${head}${body}</table></div>`;
+
+        // Positioning
+        statOverlay.style.top = statOverlay.style.bottom = statOverlay.style.left = statOverlay.style.right = '';
+        statOverlay.style.transform = '';
+        switch(statData.position){
+            case 'top-left':
+                statOverlay.style.top = '2rem';
+                statOverlay.style.left = '2rem';
+                break;
+            case 'top-right':
+                statOverlay.style.top = '2rem';
+                statOverlay.style.right = '2rem';
+                break;
+            case 'bottom-left':
+                statOverlay.style.bottom = '2rem';
+                statOverlay.style.left = '2rem';
+                break;
+            case 'bottom-right':
+                statOverlay.style.bottom = '2rem';
+                statOverlay.style.right = '2rem';
+                break;
+            case 'top-center':
+                statOverlay.style.top = '2rem';
+                statOverlay.style.left = '50%';
+                statOverlay.style.transform = 'translateX(-50%)';
+                break;
+            default:
+                statOverlay.style.bottom = '2rem';
+                statOverlay.style.left = '50%';
+                statOverlay.style.transform = 'translateX(-50%)';
+        }
+
+        const transition = statData.transition === 'fade-slide';
+        const head = `<thead class='stat-head ${transition?'fade-in':''}'><tr><th></th><th>${statData.teamA}</th><th>${statData.teamB}</th></tr></thead>`;
+        const body = `<tbody class='stat-body ${transition?'slide-down':''}'>${statData.rows.map(r=>`<tr><td>${r.label}</td><td>${r.a}</td><td>${r.b}</td></tr>`).join('')}</tbody>`;
+        statOverlay.innerHTML = `<div class='stats-box ${statData.style || 'standard'}'><table>${head}${body}</table></div>`;
     } else if (statOverlay) {
         statOverlay.remove();
     }

--- a/wwwroot/app/js/socialAssets.js
+++ b/wwwroot/app/js/socialAssets.js
@@ -2,7 +2,9 @@ import { getEventMetadata, getMatchLogEntry } from './firebase.js';
 import { getDatabaseInstance } from './firebaseApp.js';
 import { ref, get } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js';
 
-const worker = new Worker('./graphicsWorker.js', { type: 'module' });
+// Resolve worker relative to this module so social page can locate it regardless
+// of the current document path.
+const worker = new Worker(new URL('./graphicsWorker.js', import.meta.url), { type: 'module' });
 const pending = new Map();
 let wid = 0;
 
@@ -36,9 +38,9 @@ export async function generateSocialAssets(eventId, logId, style, options = {}) 
   const entry = await getMatchLogEntry(eventId, logId);
   const meta = await getCachedEventMeta(eventId);
   const dyn = {
-    homeLogo: `/assets/logos/${meta.homeSlug}.png`,
-    awayLogo: `/assets/logos/${meta.awaySlug}.png`,
-    portrait: `/assets/portraits/${entry.playerId}.jpg`,
+    homeLogo: options.includeTeamLogos === false ? '' : `/assets/logos/${meta.homeSlug}.png`,
+    awayLogo: options.includeTeamLogos === false ? '' : `/assets/logos/${meta.awaySlug}.png`,
+    portrait: options.includePlayerPhotos === false ? '' : `/assets/portraits/${entry.playerId}.jpg`,
     playerName: entry.playerName,
     playerNumber: entry.playerNumber || '',
     eventType: entry.eventType,
@@ -63,8 +65,8 @@ export async function generateFinalScoreAssets(eventId, style, options = {}) {
   ]);
   const scores = sbSnap?.scores || [meta.scoreHome, meta.scoreAway];
   const dyn = {
-    homeLogo: `/assets/logos/${meta.homeSlug}.png`,
-    awayLogo: `/assets/logos/${meta.awaySlug}.png`,
+    homeLogo: options.includeTeamLogos === false ? '' : `/assets/logos/${meta.homeSlug}.png`,
+    awayLogo: options.includeTeamLogos === false ? '' : `/assets/logos/${meta.awaySlug}.png`,
     eventType: 'Full Time',
     scoreline: `${scores[0]} – ${scores[1]}`,
     playerName: '',

--- a/wwwroot/app/js/socialAssets.js
+++ b/wwwroot/app/js/socialAssets.js
@@ -40,6 +40,7 @@ export async function generateSocialAssets(eventId, logId, style, options = {}) 
     awayLogo: `/assets/logos/${meta.awaySlug}.png`,
     portrait: `/assets/portraits/${entry.playerId}.jpg`,
     playerName: entry.playerName,
+    playerNumber: entry.playerNumber || '',
     eventType: entry.eventType,
     scoreline: `${meta.scoreHome} – ${meta.scoreAway}`,
     time: entry.time

--- a/wwwroot/app/js/templates/socialTemplates.js
+++ b/wwwroot/app/js/templates/socialTemplates.js
@@ -3,14 +3,17 @@ export const SOCIAL_TEMPLATES = {
     '9x16': [
       { type: 'rect', x: 0, y: 0, w: 1, h: 1, color: '#000' },
       { type: 'image', x: 0.05, y: 0.05, w: 0.3, h: 0.3, src: 'homeLogo', mode: 'contain' },
+      { type: 'text', x: 0.5, y: 0.7, w: 0.9, h: 0.1, text: 'playerNumber', color: '#fff', align: 'center', font: '40px sans-serif' },
       { type: 'text', x: 0.5, y: 0.8, w: 0.9, h: 0.1, text: 'playerName', color: '#fff', align: 'center', font: '48px sans-serif' }
     ],
     '1x1': [
       { type: 'rect', x:0, y:0, w:1, h:1, color:'#000' },
+      { type: 'text', x:0.5, y:0.35, w:0.9, h:0.2, text:'playerNumber', color:'#fff', align:'center', font:'28px sans-serif' },
       { type: 'text', x:0.5, y:0.5, w:0.9, h:0.2, text:'playerName', color:'#fff', align:'center', font:'32px sans-serif' }
     ],
     '2x3': [
       { type:'rect', x:0, y:0, w:1, h:1, color:'#000' },
+      { type:'text', x:0.5, y:0.55, w:0.9, h:0.2, text:'playerNumber', color:'#fff', align:'center', font:'36px sans-serif' },
       { type:'text', x:0.5, y:0.7, w:0.9, h:0.2, text:'playerName', color:'#fff', align:'center', font:'40px sans-serif' }
     ]
   },

--- a/wwwroot/app/js/templates/socialTemplates.js
+++ b/wwwroot/app/js/templates/socialTemplates.js
@@ -44,5 +44,31 @@ export const SOCIAL_TEMPLATES = {
       { type:'rect', x:0, y:0, w:1, h:1, color:'#ffffff' },
       { type:'text', x:0.5, y:0.6, w:0.9, h:0.2, text:'scoreline', color:'#000', align:'center', font:'50px sans-serif' }
     ]
+  },
+  bold: {
+    '9x16': [
+      { type:'rect', x:0, y:0, w:1, h:1, color:'#000' },
+      { type:'image', x:0, y:0, w:1, h:1, src:'portrait', mode:'cover' },
+      { type:'rect', x:0, y:0, w:1, h:1, color:'rgba(0,0,0,0.4)' },
+      { type:'rect', x:0, y:0.65, w:1, h:0.35, color:'#e16316' },
+      { type:'text', x:0.5, y:0.75, w:0.9, h:0.1, text:'playerNumber', color:'#fff', align:'center', font:'bold 72px sans-serif' },
+      { type:'text', x:0.5, y:0.85, w:0.9, h:0.1, text:'playerName', color:'#fff', align:'center', font:'bold 48px sans-serif' }
+    ],
+    '1x1': [
+      { type:'rect', x:0, y:0, w:1, h:1, color:'#000' },
+      { type:'image', x:0, y:0, w:1, h:1, src:'portrait', mode:'cover' },
+      { type:'rect', x:0, y:0, w:1, h:1, color:'rgba(0,0,0,0.4)' },
+      { type:'rect', x:0, y:0.65, w:1, h:0.35, color:'#e16316' },
+      { type:'text', x:0.5, y:0.78, w:0.9, h:0.1, text:'playerNumber', color:'#fff', align:'center', font:'bold 56px sans-serif' },
+      { type:'text', x:0.5, y:0.9, w:0.9, h:0.1, text:'playerName', color:'#fff', align:'center', font:'bold 32px sans-serif' }
+    ],
+    '2x3': [
+      { type:'rect', x:0, y:0, w:1, h:1, color:'#000' },
+      { type:'image', x:0, y:0, w:1, h:1, src:'portrait', mode:'cover' },
+      { type:'rect', x:0, y:0, w:1, h:1, color:'rgba(0,0,0,0.4)' },
+      { type:'rect', x:0, y:0.65, w:1, h:0.35, color:'#e16316' },
+      { type:'text', x:0.5, y:0.78, w:0.9, h:0.1, text:'playerNumber', color:'#fff', align:'center', font:'bold 64px sans-serif' },
+      { type:'text', x:0.5, y:0.9, w:0.9, h:0.1, text:'playerName', color:'#fff', align:'center', font:'bold 40px sans-serif' }
+    ]
   }
 };


### PR DESCRIPTION
## Summary
- Rename Intro Graphics “Input” button to “Input data” and capture venue, event date, and weather location.
- Add fixtures, formation, and course detail controls with preview/live/edit options and modal configuration.
- Support hiding new overlays from active graphics panel.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689072e21510832381f4e95d5c136aab